### PR TITLE
custom-role-mapper (trivial mapped-role-mapper)

### DIFF
--- a/custom-role-mapper/.gitignore
+++ b/custom-role-mapper/.gitignore
@@ -1,0 +1,6 @@
+.classpath
+.project
+.settings
+.idea
+*.iml
+/target/

--- a/custom-role-mapper/README.md
+++ b/custom-role-mapper/README.md
@@ -1,0 +1,34 @@
+Simple role-mapper for WildFly Elytron
+======================================
+
+Simple role mapper, which maps roles as configured in custom-role-mapper definition.
+
+Maps role from key in the configuration map to appropriate value.
+
+This can be used as trivial replacement of mapped-role-mapper for AS which does not provide mapped-role-mapper.
+
+Usage
+*****
+
+Compile:
+
+        mvn package
+
+Add the module into the WildFly:
+
+        bin/jboss-cli.sh
+        module add --name=org.wildfly.security.examples.custom-role-mapper --resources=custom-role-mapper-1.0.0.Alpha1-SNAPSHOT.jar --dependencies=org.wildfly.security.elytron,org.wildfly.extension.elytron
+
+Add a custom-role-mapper into the subsystem:
+
+        /subsystem=elytron/custom-role-mapper=myRoleMapper:add(module=org.wildfly.security.examples.custom-role-mapper, class-name=org.wildfly.security.examples.MyRoleMapper, configuration={roleA=role1, roleB=role2})
+
+Example resulting XML:
+
+        <custom-role-mapper name="myRoleMapper" module="org.wildfly.security.examples.custom-role-mapper" class-name="org.wildfly.security.examples.MyRoleMapper">
+            <configuration>
+                <property name="roleA" value="role1"/>
+                <property name="roleB" value="role2"/>
+            </configuration>
+        </custom-role-mapper>
+

--- a/custom-role-mapper/pom.xml
+++ b/custom-role-mapper/pom.xml
@@ -1,0 +1,33 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.wildfly.security.examples</groupId>
+    <artifactId>custom-role-mapper</artifactId>
+    <version>1.0.0.Alpha1-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <version.org.wildfly.security.wildfly-elytron>1.1.10.Final</version.org.wildfly.security.wildfly-elytron>
+        <version.org.wildfly.core>3.0.10.Final</version.org.wildfly.core>
+    </properties>
+
+    <dependencies>
+        <!-- interface SecurityRealm -->
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron</artifactId>
+            <version>${version.org.wildfly.security.wildfly-elytron}</version>
+        </dependency>
+        <!-- interface Configurable - not needed for WildFly 14+ -->
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-elytron-integration</artifactId>
+            <version>${version.org.wildfly.core}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/custom-role-mapper/src/main/java/org/wildfly/security/examples/MyRoleMapper.java
+++ b/custom-role-mapper/src/main/java/org/wildfly/security/examples/MyRoleMapper.java
@@ -1,0 +1,39 @@
+package org.wildfly.security.examples;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+import org.wildfly.extension.elytron.Configurable;
+import org.wildfly.security.authz.RoleMapper;
+import org.wildfly.security.authz.Roles;
+
+/**
+ * Simple role-mapper, which maps role from key in configuration map to appropriate value.
+ */
+public class MyRoleMapper implements RoleMapper, Configurable {
+
+    private Map<String, String> configuration;
+
+    @Override
+    public void initialize(final Map<String, String> configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    public Roles mapRoles(Roles rolesToMap) {
+        Set<String> mappedRoles = new HashSet<>();
+        Iterator<String> iterator = rolesToMap.iterator();
+
+        while(iterator.hasNext()) {
+            String mappedRole = configuration.get(iterator.next());
+            if (mappedRole != null) {
+                mappedRoles.add(mappedRole);
+            }
+        }
+
+        return Roles.fromSet(mappedRoles);
+    }
+
+}


### PR DESCRIPTION
Example requested by akalashn.
Trivial replacement of mapped-role-mapper for AS which does not provide mapped-role-mapper.
Compatible with EAP 7.1