### PR TITLE
JDBC Security Realm Example with BCrypt password

### DIFF
--- a/jdbc-security-realm-bcrypt-password/README.md
+++ b/jdbc-security-realm-bcrypt-password/README.md
@@ -1,0 +1,47 @@
+## Using a JDBC Security Realm
+
+This example shows how to use a JDBC security realm with BCrypt passwords.
+
+
+
+### Usage
+
+1. Run the wildfly server
+```
+{path_to_wildfly}/bin/standalone.sh
+```
+2. Navigate to the source folder of this example and configure elytron
+```
+{path_to_wildfly}/bin/jboss-cli.sh --connect --file=configure-server.cli
+```
+
+3. Build and deploy the artifacts
+```
+mvn clean package install wildfly:deploy
+```
+#### Now you can access the the quickstart at http://localhost:8080/jdbc-security-realm-bcrypt-password
+
+When logging in using **quickstartUser** with password **quickstartPwd1!**, you will successfully see some security information
+```
+Successfully called Secured Servlet
+
+Principal : quickstartUser
+Remote User : quickstartUser
+Authentication Type : BASIC
+```
+
+When logging in using **guest** with password **guestPwd1!**, the browser will display the following error:
+
+```
+Forbidden
+```
+
+### To restore wildfly to its initial configuration
+```
+{path_to_wildfly}/bin/jboss-cli.sh --connect --file=restore-configuration.cli
+```
+
+### To undeploy the artifact
+```
+mvn clean package install wildfly:undeploy
+```

--- a/jdbc-security-realm-bcrypt-password/configure-server.cli
+++ b/jdbc-security-realm-bcrypt-password/configure-server.cli
@@ -1,0 +1,36 @@
+# Batch script to configure the security domain and define the database query used to authenticate users
+batch
+
+
+# Start by creating the JDBC datasource
+/subsystem=datasources/data-source=ServletSecurityDS:add(connection-url="jdbc:h2:mem:servlet-security;DB_CLOSE_ON_EXIT=FALSE", jndi-name="java:jboss/datasources/ServletSecurityDS", driver-name=h2, user-name="sa", password="sa")
+
+# Add the JDBC security realm creation
+#Comment out the following line if using hex encoding or modular crypt passwords
+/subsystem=elytron/jdbc-realm=servlet-security-jdbc-realm:add(principal-query=[{sql="SELECT PASSWORD, SALT, ITERATION_COUNT FROM USERS WHERE USERNAME = ?", data-source="ServletSecurityDS", bcrypt-mapper={password-index=1, salt-index=2, iteration-count-index=3}},{sql="SELECT R.NAME, 'Roles' FROM USERS_ROLES UR INNER JOIN ROLES R ON R.ID = UR.ROLE_ID INNER JOIN USERS U ON U.ID = UR.USER_ID WHERE U.USERNAME = ?", data-source="ServletSecurityDS", attribute-mapping=[{index=1, to=roles}]}])
+
+#Uncomment the following line for hex encoding
+#/subsystem=elytron/jdbc-realm=servlet-security-jdbc-realm:add(principal-query=[{sql="SELECT PASSWORD, SALT, ITERATION_COUNT FROM USERS WHERE USERNAME = ?", data-source="ServletSecurityDS", bcrypt-mapper={password-index=1, hash-encoding=hex, salt-index=2, salt-encoding=hex, iteration-count-index=3}},{sql="SELECT R.NAME, 'Roles' FROM USERS_ROLES UR INNER JOIN ROLES R ON R.ID = UR.ROLE_ID INNER JOIN USERS U ON U.ID = UR.USER_ID WHERE U.USERNAME = ?", data-source="ServletSecurityDS", attribute-mapping=[{index=1, to=roles}]}])
+
+#Uncomment the following line for modular crypt passwords
+#/subsystem=elytron/jdbc-realm=servlet-security-jdbc-realm:add(principal-query=[{sql="SELECT PASSWORD FROM USERS WHERE USERNAME = ?", data-source="ServletSecurityDS", modular-crypt-mapper={password-index=1}},{sql="SELECT R.NAME, 'Roles' FROM USERS_ROLES UR INNER JOIN ROLES R ON R.ID = UR.ROLE_ID INNER JOIN USERS U ON U.ID = UR.USER_ID WHERE U.USERNAME = ?", data-source="ServletSecurityDS", attribute-mapping=[{index=1, to=roles}]}])
+
+# Add a simple role decoder for the "roles" attribute mapping
+/subsystem=elytron/simple-role-decoder=from-roles-attribute:add(attribute=roles)
+
+# Configure the servlet-security-quickstart security domain
+/subsystem=elytron/security-domain=servlet-security-quickstart-sd:add(default-realm=servlet-security-jdbc-realm, realms=[{realm=servlet-security-jdbc-realm, role-decoder=from-roles-attribute}], permission-mapper=default-permission-mapper)
+
+# Configure the HTTP Authentication Factory
+/subsystem=elytron/http-authentication-factory=servlet-security-quickstart-http-auth:add(http-server-mechanism-factory=global,security-domain=servlet-security-quickstart-sd,mechanism-configurations=[{mechanism-name=BASIC,mechanism-realm-configurations=[{realm-name=RealmUsersRoles}]}])
+
+# Configure Undertow's application security domain
+/subsystem=undertow/application-security-domain=servlet-security-quickstart:add(http-authentication-factory=servlet-security-quickstart-http-auth)
+
+# Run the batch commands
+run-batch
+
+# Reload the server configuration
+reload
+
+

--- a/jdbc-security-realm-bcrypt-password/pom.xml
+++ b/jdbc-security-realm-bcrypt-password/pom.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2019, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.wildfly.security.examples</groupId>
+    <artifactId>jdbc-security-realm-bcrypt-password</artifactId>
+    <version>1.0.0.Alpha1-SNAPSHOT</version>
+
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <version.org.wildfly.security.wildfly-elytron>1.9.1.Final</version.org.wildfly.security.wildfly-elytron>
+    </properties>
+
+    <packaging>war</packaging>
+    <name>Elytron Example: jdbc-security-realm-bcrypt-password</name>
+    <description>This project demonstrates a use of a JDBC security realm using a BCrypt hashed password</description>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron</artifactId>
+            <version>${version.org.wildfly.security.wildfly-elytron}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <version>1.0.2.Final</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>jdbc-security-realm-bcrypt-password</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <configuration>
+                    <executable>java</executable>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>generate-bcrypt-password</id>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <notimestamp>true</notimestamp>
+                    <doclint>none</doclint>
+                    <show>protected</show>
+                    <sourceFileIncludes>
+                        <include>org/wildfly/security/examples/GenerateBCryptExample.java</include>
+                    </sourceFileIncludes>
+                    <destDir>javadoc</destDir>
+                </configuration>
+                <executions>
+                    <execution><!-- mvn javadoc:javadoc@full-javadoc -->
+                        <id>full-javadoc</id>
+                        <configuration>
+                            <destDir>full-javadoc</destDir>
+                            <show>private</show>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- WildFly plug-in to deploy the WAR -->
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>2.0.1.Final</version>
+        </plugin>
+        </plugins>
+    </build>
+</project>

--- a/jdbc-security-realm-bcrypt-password/restore-configuration.cli
+++ b/jdbc-security-realm-bcrypt-password/restore-configuration.cli
@@ -1,0 +1,32 @@
+# Batch script to remove the servlet-security-quickstart domain from the server configuration file
+
+# Start batching commands
+batch
+
+# Remove Undertow's application security domain
+/subsystem=undertow/application-security-domain=servlet-security-quickstart:remove()
+
+# Remove the HTTP Authentication Factory
+/subsystem=elytron/http-authentication-factory=servlet-security-quickstart-http-auth:remove()
+
+# Remove the servlet-security-quickstart security domain
+/subsystem=elytron/security-domain=servlet-security-quickstart-sd:remove()
+
+# Remove a simple role decoder for the "roles" attribute mapping
+/subsystem=elytron/simple-role-decoder=from-roles-attribute:remove()
+
+# Remove the JDBC security realm creation
+/subsystem=elytron/jdbc-realm=servlet-security-jdbc-realm:remove()
+
+# Remove the JDBC datasource
+/subsystem=datasources/data-source=ServletSecurityDS:remove()
+
+
+ undeploy jdbc-security-realm-bcrypt-password.war
+
+# Run the batch commands
+run-batch
+
+# Reload the server configuration
+reload
+

--- a/jdbc-security-realm-bcrypt-password/src/main/java/org/wildfly/security/examples/GenerateBCryptPassword.java
+++ b/jdbc-security-realm-bcrypt-password/src/main/java/org/wildfly/security/examples/GenerateBCryptPassword.java
@@ -1,0 +1,102 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.examples;
+
+
+import java.security.Provider;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+import org.wildfly.common.iteration.ByteIterator;
+import org.wildfly.security.WildFlyElytronProvider;
+import org.wildfly.security.password.PasswordFactory;
+import org.wildfly.security.password.interfaces.BCryptPassword;
+import org.wildfly.security.password.spec.EncryptablePasswordSpec;
+import org.wildfly.security.password.spec.IteratedSaltedPasswordAlgorithmSpec;
+import org.wildfly.security.password.util.ModularCrypt;
+
+/**
+ * Creates and prints the hashed password and salt for passwords, with default base64 encoding. Hex encoding or modular
+ * crypt can be specified
+ *
+ * @author <a href="mailto:aabdelsa@redhat.com">Ashley Abdel-Sayed</a>
+ *  
+ */
+public class GenerateBCryptPassword {
+
+    static final Provider ELYTRON_PROVIDER = new WildFlyElytronProvider();
+
+    /*
+     * args[0] should be set to "true" if hex encoding is desired, false otherwise
+     * args[1] should be set to "true" if modular crypt encoding is desired, false otherwise
+     * args[2] should be set to the clear text password you would like to encode
+     *
+     */
+
+    public static void main(String[] args) throws Exception {
+
+        boolean hexEncoding = Boolean.parseBoolean(args[0]);
+        boolean modEncoding = Boolean.parseBoolean(args[1]);
+        String PASSWORD = args[2];
+
+        createBCryptPassword(PASSWORD, hexEncoding, modEncoding);
+
+
+    }
+    /*
+     * Generates and prints a BCrypt password and salt with default 10 iteration counts and base64 encoding.
+     * Hex encoding rather than base64 encoding can be specified.
+     * Modular crypt encoding can be specified and the password, salt, and iteration counts can be encoded
+     * in a single string.
+     *
+     */
+    public static void createBCryptPassword(String password, boolean hexEncoded, boolean modEncoding) throws Exception {
+        PasswordFactory passwordFactory = PasswordFactory.getInstance(BCryptPassword.ALGORITHM_BCRYPT, ELYTRON_PROVIDER);
+
+        int iterationCount = 10;
+
+        byte[] salt = new byte[BCryptPassword.BCRYPT_SALT_SIZE];
+        SecureRandom random = new SecureRandom();
+        random.nextBytes(salt);
+
+        IteratedSaltedPasswordAlgorithmSpec iteratedAlgorithmSpec = new IteratedSaltedPasswordAlgorithmSpec(iterationCount, salt);
+        EncryptablePasswordSpec encryptableSpec = new EncryptablePasswordSpec(password.toCharArray(), iteratedAlgorithmSpec);
+
+        BCryptPassword original = (BCryptPassword) passwordFactory.generatePassword(encryptableSpec);
+
+
+        if(modEncoding) {
+            String modularCryptString = ModularCrypt.encodeAsString(original);
+            System.out.println("Modular Crypt = " + modularCryptString);
+        } else {
+            byte[] hash = original.getHash();
+            String encodedHash;
+            String encodedSalt;
+            if(hexEncoded) {
+                encodedHash = ByteIterator.ofBytes(hash).hexEncode().drainToString();
+                encodedSalt = ByteIterator.ofBytes(salt).hexEncode().drainToString();
+
+            } else {
+                Base64.Encoder encoder = Base64.getEncoder();
+                encodedHash = encoder.encodeToString(hash);
+                encodedSalt = encoder.encodeToString(salt);
+            }
+            System.out.println("Encoded Hash = " + encodedHash);
+            System.out.println("Encoded Salt = " + encodedSalt);
+        }
+    }
+}

--- a/jdbc-security-realm-bcrypt-password/src/main/java/org/wildfly/security/examples/SecuredServlet.java
+++ b/jdbc-security-realm-bcrypt-password/src/main/java/org/wildfly/security/examples/SecuredServlet.java
@@ -1,0 +1,70 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.examples;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.security.Principal;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.HttpConstraint;
+import javax.servlet.annotation.ServletSecurity;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * A simple secured Servlet. Upon successful authentication and authorization the Servlet will print details of the user and
+ * authentication. Servlet security is implemented using annotations.
+ *
+ * @author Sherif Makary
+ *
+ */
+@SuppressWarnings("serial")
+@WebServlet("/SecuredServlet")
+@ServletSecurity(@HttpConstraint(rolesAllowed = { "quickstarts" }))
+public class SecuredServlet extends HttpServlet {
+
+    private static String PAGE_HEADER = "<html><head><title>servlet-security</title></head><body>";
+
+    private static String PAGE_FOOTER = "</body></html>";
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        PrintWriter writer = resp.getWriter();
+        Principal principal = null;
+        String authType = null;
+        String remoteUser = null;
+
+        // Get security principal
+        principal = req.getUserPrincipal();
+        // Get user name from login principal
+        remoteUser = req.getRemoteUser();
+        // Get authentication type
+        authType = req.getAuthType();
+
+        writer.println(PAGE_HEADER);
+        writer.println("<h1>" + "Successfully called Secured Servlet " + "</h1>");
+        writer.println("<p>" + "Principal  : " + principal.getName() + "</p>");
+        writer.println("<p>" + "Remote User : " + remoteUser + "</p>");
+        writer.println("<p>" + "Authentication Type : " + authType + "</p>");
+        writer.println(PAGE_FOOTER);
+        writer.close();
+    }
+
+}

--- a/jdbc-security-realm-bcrypt-password/src/main/resources/META-INF/persistence.xml
+++ b/jdbc-security-realm-bcrypt-password/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<persistence version="2.1"
+    xmlns="http://xmlns.jcp.org/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+        http://xmlns.jcp.org/xml/ns/persistence
+        http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
+    <persistence-unit name="primary">
+        <!-- If you are running in a production environment, add a managed
+            data source, this example data source is just for development and testing! -->
+        <!-- The datasource is deployed as WEB-INF/servlet-security-quickstart-ds.xml,
+            you can find it in the source at src/main/webapp/WEB-INF/servlet-security-quickstart-ds.xml -->
+        <jta-data-source>java:jboss/datasources/ServletSecurityDS</jta-data-source>
+        <properties>
+            <!-- Properties for Hibernate -->
+            <property name="hibernate.hbm2ddl.auto" value="create-drop" />
+            <property name="hibernate.show_sql" value="false" />
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/jdbc-security-realm-bcrypt-password/src/main/resources/import.sql
+++ b/jdbc-security-realm-bcrypt-password/src/main/resources/import.sql
@@ -1,0 +1,44 @@
+--
+-- JBoss, Home of Professional Open Source
+-- Copyright 2019, Red Hat, Inc. and/or its affiliates, and individual
+-- contributors by the @authors tag. See the copyright.txt in the
+-- distribution for a full listing of individual contributors.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+-- http://www.apache.org/licenses/LICENSE-2.0
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+--Comment out the following line when using modular crypt
+CREATE TABLE USERS (ID INT, USERNAME VARCHAR(20), PASSWORD VARCHAR(60), SALT VARCHAR(60), ITERATION_COUNT INT);
+
+--Uncomment the following line when using modular crypt
+--CREATE TABLE USERS (ID INT, USERNAME VARCHAR(20), PASSWORD VARCHAR(60));
+
+CREATE TABLE ROLES (ID INT, NAME VARCHAR(20));
+CREATE TABLE USERS_ROLES (USER_ID INT, ROLE_ID INT);
+
+--Comment out the following two lines when using hex encoding or modular crypt
+INSERT INTO USERS (ID, USERNAME, PASSWORD, SALT, ITERATION_COUNT) VALUES (1, 'quickstartUser', 'NxHRwFg/YkkRgGUq/D6ARnD+caxlmIg=', 'DMakCMy9DYKBVW/HNrCrPw==',10);
+INSERT INTO USERS (ID, USERNAME, PASSWORD, SALT, ITERATION_COUNT) VALUES (2, 'guest', 'sspDe1PYqDdAJ5EeHoRJcXZPuM+vOi8=', 'VO0V0x+j/oZ5r7VvxdzDzw==', 10);
+
+--Uncomment following two lines when using hex encoding
+--INSERT INTO USERS (ID, USERNAME, PASSWORD, SALT, ITERATION_COUNT) VALUES (1, 'quickstartUser', '1b16d96be4b63b73d6ec7008f656effefa94ddfa5daa14', 'd75ef1b0445dde97315936f8cb62d960',10);
+--INSERT INTO USERS (ID, USERNAME, PASSWORD, SALT, ITERATION_COUNT) VALUES (2, 'guest', 'c4537f43dd62c6c854a7e39378a972bcca8df71810954d', 'a1f8cff8469a6d8203905c38345fc5a3', 10);
+
+
+--Uncomment following two lines to use modular crypt
+--INSERT INTO USERS (ID, USERNAME, PASSWORD) VALUES (1, 'quickstartUser', '$2a$10$5P6AM77To04c0MQuW0eRnOVfBBHQz5kdefCGdErgjVCfCgrF4CO/.');
+--INSERT INTO USERS (ID, USERNAME, PASSWORD) VALUES (2, 'guest', '$2a$10$ZBubpz1cCVvNGxkA/hNRz.9MHT5NmR1oh3ToLw8a9xEm8OcOwUV6C');
+
+INSERT INTO ROLES (ID, NAME) VALUES (1, 'quickstarts');
+INSERT INTO ROLES (ID, NAME) VALUES (2, 'guest');
+
+INSERT INTO USERS_ROLES (USER_ID, ROLE_ID) VALUES (1,1);
+INSERT INTO USERS_ROLES (USER_ID, ROLE_ID) VALUES (2,2);

--- a/jdbc-security-realm-bcrypt-password/src/main/webapp/WEB-INF/beans.xml
+++ b/jdbc-security-realm-bcrypt-password/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!-- Marker file indicating CDI should be enabled -->
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+      http://xmlns.jcp.org/xml/ns/javaee
+      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+    bean-discovery-mode="all">
+</beans>

--- a/jdbc-security-realm-bcrypt-password/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/jdbc-security-realm-bcrypt-password/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!DOCTYPE jboss-web>
+<jboss-web xmlns="http://www.jboss.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.jboss.org/schema/jbossas
+    http://www.jboss.org/schema/jbossas/jboss-web_7_2.xsd">
+   <!-- Configure usage of the security domain "other" -->
+   <security-domain>servlet-security-quickstart</security-domain>
+   <disable-audit>true</disable-audit>
+</jboss-web>

--- a/jdbc-security-realm-bcrypt-password/src/main/webapp/WEB-INF/web.xml
+++ b/jdbc-security-realm-bcrypt-password/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<web-app version="3.1" xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
+
+   <!-- Configure login to be HTTP Basic -->
+   <login-config>
+      <auth-method>BASIC</auth-method>
+      <realm-name>RealmUsersRoles</realm-name>
+   </login-config>
+</web-app>
+

--- a/jdbc-security-realm-bcrypt-password/src/main/webapp/index.html
+++ b/jdbc-security-realm-bcrypt-password/src/main/webapp/index.html
@@ -1,0 +1,23 @@
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!-- Plain HTML page that kicks us into the app -->
+
+<html>
+<head>
+<meta http-equiv="Refresh" content="0; URL=SecuredServlet">
+</head>
+</html>


### PR DESCRIPTION
This is a new example to demonstrate how to use JDBC SecurityRealm to load a BCrypt password with base64 encoding, hex encoding and as a modular crypt password. 