### PR TITLE
Adding option for custom distinguished names

### DIFF
--- a/dynamic-certificates/README.md
+++ b/dynamic-certificates/README.md
@@ -1,0 +1,15 @@
+## Dynamic Certificates
+
+This example can be used to generate certificates for two way ssl.
+
+### Usage
+
+* To run with default distinguished names (CN=client1 and CN=client2), navigate to the home directory of this project
+and run the following command
+```
+mvn clean install exec:java -Dexec.mainClass="org.wildfly.security.examples.CertificateGenerationExample"
+```
+* To run with custom distinguished names, navigate to the home directory of this project and run the following command
+```
+mvn clean install exec:java -Dexec.mainClass="org.wildfly.security.examples.CertificateGenerationExample" -Dexec.args="CN=customName1 CN=customName2"
+```

--- a/dynamic-certificates/pom.xml
+++ b/dynamic-certificates/pom.xml
@@ -37,11 +37,6 @@
                 <version>1.6.0</version>
                 <configuration>
                     <executable>java</executable>
-                    <arguments>
-                        <argument>-classpath</argument>
-                        <classpath />
-                        <argument>org.wildfly.security.examples.CertificateGenerationExample</argument>
-                    </arguments>
                 </configuration>
                 <executions>
                     <execution>

--- a/dynamic-certificates/src/main/java/org/wildfly/security/examples/CertificateGenerationExample.java
+++ b/dynamic-certificates/src/main/java/org/wildfly/security/examples/CertificateGenerationExample.java
@@ -31,14 +31,25 @@ public class CertificateGenerationExample {
     private static String outputLocation = CertificateGenerationExample.class.getProtectionDomain().getCodeSource().getLocation().getPath() + "dynamic-certificates/custom/";
 
     public static void main(String[] args) throws Exception {
-        generateKeyStoresForTwoWaySSL();
+        ArrayList<String> distinguishedNamesList = new ArrayList<>();
+        if(args.length == 0) {
+            distinguishedNamesList.add("CN=client1");
+            distinguishedNamesList.add("CN=client2");
+        } else {
+            for (int i = 0; i < 2; i++) {
+                distinguishedNamesList.add(args[i]);
+            }
+        }
+        generateKeyStoresForTwoWaySSL(distinguishedNamesList);
     }
 
-    public static void generateKeyStoresForTwoWaySSL() throws Exception {
+    public static void generateKeyStoresForTwoWaySSL(ArrayList<String> distinguishedNamesList) throws Exception {
         new CertificateGenerator.Builder()
                 .setOutputLocation(new File(CertificateGenerationExample.class.getProtectionDomain().getCodeSource().getLocation().getPath()).getParentFile().toString())
                 .build()
-                .generateTwoWaySSL();
+                .generateTwoWaySSL(distinguishedNamesList);
+
+
     }
 
     public void generateKeyStoresWithDefaults() throws Exception {

--- a/dynamic-certificates/src/main/java/org/wildfly/security/examples/CertificateGenerator.java
+++ b/dynamic-certificates/src/main/java/org/wildfly/security/examples/CertificateGenerator.java
@@ -434,8 +434,15 @@ public class CertificateGenerator {
      * @throws Exception Errors encountered during generation, described in their corresponding methods
      */
     public void generateTwoWaySSL() throws Exception {
+        ArrayList<String> distinguishedNamesList = new ArrayList<>();
+        distinguishedNamesList.add("CN=client1");
+        distinguishedNamesList.add("CN=client2");
+        generateTwoWaySSL(distinguishedNamesList);
+    }
+
+    public void generateTwoWaySSL(ArrayList<String> distinguishedNames) throws Exception {
         addAlias("client1");
-        addDistinguishedName("CN=client1");
+        addDistinguishedName(distinguishedNames.get(0));
         setTrustStoreName("server.truststore");
         setKeyStoreName("client1.keystore");
         SelfSignedX509CertificateAndSigningKey authority = createAuthority();
@@ -448,7 +455,7 @@ public class CertificateGenerator {
         clearAliases();
         clearDistinguishedNames();
         addAlias("client2");
-        addDistinguishedName("CN=client2");
+        addDistinguishedName(distinguishedNames.get(1));
         certificates = createSignedCertificates(authority);
         createKeyStoreAndTrustStore(authority, certificates);
         saveKeyStoreToFile();


### PR DESCRIPTION
To run with default distinguished names:
mvn clean install exec:java -Dexec.mainClass="org.wildfly.security.examples.CertificateGenerationExample" -Dexec.args=""

To run with custom distinguished names:
mvn clean install exec:java -Dexec.mainClass="org.wildfly.security.examples.CertificateGenerationExample" -Dexec.args="CN=customName1 CN=customName2"

