### PR TITLE
 Add an example that demonstrates how to use CLIENT_CERT HTTP authentication with two-way SSL and authorization 

### DIFF
--- a/client-cert-with-authorization/README.md
+++ b/client-cert-with-authorization/README.md
@@ -1,0 +1,102 @@
+## Using certificate-based authentication with authorization
+
+This example shows how to secure a web application deployed to WildFly using the CLIENT_CERT HTTP authentication
+mechanism with two-way SSL and authorization. The server’s truststore will only contain an example CA certificate,
+it won’t contain any client certificates. Similarly, the security realm used for authorization in this example
+won’t contain any client certificates. It will contain principals that are derived from a portion of the CN value
+from the subject name from a client’s X.509 certificate.
+
+### Overview
+
+* [ Certificate generation ](#certGeneration)
+* [ Server configuration ](#serverConfiguration)
+* [ Deploying and accessing the application ](#deployingApp)
+
+<a name="certGeneration"></a>
+### Certificate generation
+
+First, clone the ```elytron-examples``` repo locally:
+
+```
+    git clone https://github.com/wildfly-security-incubator/elytron-examples
+    cd elytron-examples
+```
+
+Next, let's generate some client and server certificates that will be used in this example to set up two-way SSL between
+a server and two clients:
+
+```
+   cd dynamic-certificates
+   mvn clean install exec:java -Dexec.mainClass="org.wildfly.security.examples.CertificateGenerationExample" -Dexec.args="CN=Bob.Smith.123456 CN=Alice.Smith.456789"
+```
+
+The above command generates the following keystores and truststores in the ```dynamic-certificates/target``` directory:
+
+```
+   client1.keystore
+   client1.truststore
+   client2.keystore
+   client2.truststore
+   server.keystore
+   server.truststore
+```
+
+* ```client1.keystore``` contains a certificate with distinguished name: ```CN=Bob.Smith.123456```
+* ```client2.keystore``` contains a certificate with distinguished name: ```CN=Alice.Smith.456789```
+* Both client certificates are issued by an example certificate authority with distinguished name: ```CN=Elytron CA, ST=Elytron, C=UK, EMAILADDRESS=elytron@wildfly.org, O=Root Certificate Authority```
+* ```server.truststore``` contains this certificate authority's certificate
+
+Next, convert the client keystores into PKCS12 format and import them into your browser so you can pick which one to
+present to the server later on:
+
+```
+keytool -importkeystore -srckeystore client1.keystore -srcstoretype jks -destkeystore client1.keystore.pkcs12 -deststoretype pkcs12 -srcstorepass keystorepass -deststorepass keystorepass
+keytool -importkeystore -srckeystore client2.keystore -srcstoretype jks -destkeystore client2.keystore.pkcs12 -deststoretype pkcs12 -srcstorepass keystorepass -deststorepass keystorepass
+```
+
+Finally, copy the server.keystore and server.truststore files to your WildFly server instance:
+
+```
+cp $PATH_TO_ELYTRON_EXAMPLES/dynamic-certificates/target/server.* $WILDFLY_HOME/standalone/configuration
+```
+
+<a name="serverConfiguration"></a>
+### Server configuration
+
+The following command can now be used configure WildFly to secure our web application using the CLIENT_CERT HTTP
+authentication mechanism with two-way SSL and authorization. Only the client with ID 123456 will be able to access
+our secured web application
+ 
+```
+    $SERVER_HOME/bin/jboss-cli.sh --connect --file=$PATH_TO_ELYTRON_EXAMPLES/client-cert-with-authorization/configure-elytron-server.cli 
+```
+
+Take a look at the ```configure-elytron-server.cli``` file in the ```client-cert-with-authorization``` directory for more
+details on the configuration.
+
+<a name="deployingApp"></a>
+### Deploying and accessing the application
+
+We’re going to make use of the ```simple-webapp``` project. It can be deployed using the following commands:
+
+```
+cd $PATH_TO_ELYTRON_EXAMPLES/simple-webapp
+mvn clean install wildfly:deploy
+```
+
+Then try accessing the application using https://localhost:8443/simple-webapp
+
+Note that since the server's certificate won't be trusted by your browser, you'll need to manually confirm that
+this certificate is trusted or configure your browser to trust it.
+
+First, select the certificate with for Alice.Smith.456789. Then try clicking on “Access Secured Servlet”. Notice that a
+Forbidden message occurs. This is because accessing the secured servlet requires “Users” role but the “456789” identity
+that we configured has no roles.
+
+Now, try accessing the application again. This time, select the certificate for Bob.Smith.123456 and then click on
+“Access Secured Servlet”. This time, this succeeds since the “123456” identity that we configured has “Users” role.
+
+This example has shown to secure a web application deployed to WildFly using the CLIENT_CERT HTTP authentication
+mechanism with two-way SSL with authorization. It has also demonstrated that individual client certificates do not need
+to be stored in either the server’s truststore or in its security realm.
+

--- a/client-cert-with-authorization/configure-elytron-server.cli
+++ b/client-cert-with-authorization/configure-elytron-server.cli
@@ -1,0 +1,29 @@
+# Obtain CN value from X.509 certificate subject name
+/subsystem=elytron/x500-attribute-principal-decoder=cnDecoder:add(attribute-name=CN, maximum-segments=1)
+
+# Match the ID portion from the CN value
+/subsystem=elytron/regex-principal-transformer=myRegexTransformer:add(pattern=".*\\.([0-9]+)",replacement="$1")
+
+# Combine the above two transformers
+/subsystem=elytron/chained-principal-transformer=myChainedTransformer:add(principal-transformers=[cnDecoder, myRegexTransformer])
+
+# Create a security realm with two identities, 123456 and 456789
+/subsystem=elytron/filesystem-realm=idsRealm:add(path=ids,relative-to=jboss.server.config.dir)
+/subsystem=elytron/filesystem-realm=idsRealm:add-identity(identity=123456)
+/subsystem=elytron/filesystem-realm=idsRealm:add-identity-attribute(identity=123456,name=Roles,value=[Users])
+/subsystem=elytron/filesystem-realm=idsRealm:add-identity(identity=456789)
+
+# Configure a security domain that references our security realm
+/subsystem=elytron/security-domain=clientCertDomain:add(realms=[{realm=idsRealm}], default-realm=idsRealm, pre-realm-principal-transformer=myChainedTransformer, permission-mapper=default-permission-mapper)
+
+# Configure two-way SSL
+/subsystem=elytron/key-store=serverTS:add(path=server.truststore,relative-to=jboss.server.config.dir,credential-reference={clear-text=truststorepass},type=JKS)
+security enable-ssl-http-server --key-store-path=server.keystore --key-store-path-relative-to=jboss.server.config.dir --key-store-password=keystorepass --trust-store-name=serverTS
+
+# Configure the CLIENT_CERT HTTP mechanism
+/subsystem=elytron/configurable-http-server-mechanism-factory=configuredCert:add(http-server-mechanism-factory=global, properties={org.wildfly.security.http.skip-certificate-verification=true})
+/subsystem=elytron/http-authentication-factory=clientCertAuth:add(http-server-mechanism-factory=configuredCert, security-domain=clientCertDomain, mechanism-configurations=[{mechanism-name=CLIENT_CERT}])
+/subsystem=undertow/application-security-domain=other:add(http-authentication-factory=clientCertAuth,override-deployment-config=true)
+
+# Reload the server instance
+reload

--- a/simple-webapp/pom.xml
+++ b/simple-webapp/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
-        <version.wildfly.maven.plugin>1.0.2.Final</version.wildfly.maven.plugin>
+        <version.wildfly.maven.plugin>2.0.0.Final</version.wildfly.maven.plugin>
         <version.jboss.spec.javaee.7.0>1.0.3.Final</version.jboss.spec.javaee.7.0>
     </properties>
 

--- a/ssl-with-authorization/README.md
+++ b/ssl-with-authorization/README.md
@@ -23,7 +23,7 @@ a server and two clients:
 
 ```
    cd dynamic-certificates
-   mvn clean install exec:exec
+   mvn clean install exec:java -Dexec.mainClass="org.wildfly.security.examples.CertificateGenerationExample"
 ```
 
 The above command generates the following keystores and truststores in the ```dynamic-certificates/target``` directory:


### PR DESCRIPTION
Also make a couple small updates to the simple-webapp and ssl-with-authorization examples.