### PR TITLE
Add an example that shows how to use hash-encoding and hash-charset

### DIFF
--- a/hash-charset-encoding/README.md
+++ b/hash-charset-encoding/README.md
@@ -1,0 +1,139 @@
+## Configuring Elytron Realms with Hash Charsets and Hash Encoding
+
+The `hash-charset-encoding` quickstart demonstrates how to secure EJBs using a filesystem realm with a hash charset and
+hash encoding configured.
+
+The purpose of this example is to demonstrate how to configure a hash charset to use when converting the client provided 
+password string to a byte array for hashing calculations. Additionally, the quickstart demonstrates how to specify the 
+string format for the hashed password if the password is not being stored in plain text in our realm.
+
+Although the example only demonstrates how to configure these 
+attributes in the filesystem realm, all realms that support storing hashed passwords can be configured 
+similarly. Namely, the Legacy Properties Realm, JDBC Realm and LDAP Realm can be configured using the same 
+attributes. 
+
+NOTE:  This example is building from the [ejb-security](https://github.com/wildfly-security-incubator/elytron-examples/tree/master/ejb-security)
+            quickstart which more closely explains how to secure EJBs. The focus of this example is the ``hash-encoding`` 
+            and ``hash-charset`` attributes in the Elytron Security Realms.
+
+### Overview
+
+This quickstart takes the following steps to implement EJB security using Elytron:
+
+1. Add a filesystem-based identity store to be used by the Elytron subsystem configuring ``KOI8-R`` as the ``hash-charset`` and
+``hex`` encoding as the string encoding.
+2. Add an identity to the Filesystem Realm which sets a password using the ``KOI8-R`` character set.
+3. Update the sasl-authentication-factory used by the Elytron subsystem to also offer ``PLAIN`` as one of its authentication mechanisms.
+This is the authentication mechanism we will be using. 
+4. Add an `application-security-domain` mapping in the `ejb3` subsystem to enable Elytron security for the `SecuredEJB`.
+
+### Use of the WILDFLY_HOME
+
+In the following instructions, replace ```WILDFLY_HOME``` with the actual path to your WildFly installation. 
+
+### Back up the WildFly Standalone Server Configuration 
+
+Before you begin, back up your server configuration file. 
+
+1. If it is running, stop the WildFly server.
+2. Back up the ```WILDFLY_HOME/standalone/configuration/standalone.xml``` file.
+
+After you have completed testing this example, you can replace this file to restore the server to its original configuration. 
+
+
+### Configuring Elytron
+
+First, clone the ```elytron-examples``` repo locally:
+```
+    git clone https://github.com/wildfly-security-incubator/elytron-examples
+    cd elytron-examples
+```
+Next, start the server:
+
+```
+    $ WILDFLY_HOME/bin/standalone.sh
+```
+
+Review the ```configure-elytron.cli``` file in the root of this quickstart directory. This script 
+adds the configuration that enables Elytron security for the quickstart components. Comments in the script 
+
+Then, open a new terminal, navigate to the root directory of this quickstart and run the following command, replacing ```WILDFLY_HOME```
+with the path to your server. 
+
+```
+    $ WILDFLY_HOME/bin/jboss-cli.sh --connect --file=configure-elytron.cli
+```
+
+NOTE: For Windows, use the ```WILDFLY_HOME\bin\jboss-cli.bat``` script.
+
+You should see the following result when you run the script:
+```$xslt
+    The batch executed successfully
+    process-state: reload-required
+```
+
+### Build and Deploy the Quickstart
+1. Make sure you start the WildFly server as described above. 
+2. Open a terminal and navigate to the root directory of this quickstart.
+3. Type the following command to build the artifacts. 
+```$xslt
+    $ mvn clean install wildfly:deploy
+```
+
+This deploys the ```{artifactId}/target/{artifactId}.jar``` to the running instance of the server.
+
+You should see a message in the server log indicating that the archive deployed successfully. 
+
+### Run the Client 
+Before you run the client, make sure you have successfully deployed the EJBs to the server in the previous step and that your 
+terminal is still in the root directory of this quickstart. 
+
+Run this command to execute the client: 
+```$xslt
+    $ mvn exec:exec
+```
+
+### Investigate the Console Output
+When you run the ```mvn exec:exec``` command, you should see the following output. 
+
+```$xslt
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+Successfully called secured bean, caller principal quickstartUser
+
+Principal has admin permission: true
+
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+```
+
+The username and credentials to establish the connection to the application server are configured in the ```wildfly-config.xml``` file. As
+expected, the ``quickstartUser`` was able to invoke the method available for the ```Guest``` role and the ```admin``` role. 
+
+###  Undeploy the Quickstart 
+1. Make sure you start the WildFly server.
+2. Open a terminal to the root directory of this quickstart. 
+3. Type this command to undeploy the archive:
+```$xslt
+    $ mvn wildfly:undeploy
+```
+
+### Restore the WildFly Standalone Server Configuration 
+You can restore the original server configuration by either: 
+1. Running the restore-configuration.cli script provided in the root directory of this quickstart.
+2. Manually restoring the configuration using the backup copy of the configuration file. 
+
+##### Restore the Wildfly Standalone Server Configuration by Running the JBoss CLI Script 
+1. Start the WildFly server. 
+2. Open a new terminal, navigate to the root directory of this quickstart, and run the following command:
+```$xslt
+    $ WILDFLY_HOME/bin/jboss-cli.sh --connect --file=restore-configuration.cli
+```
+
+NOTE: For Windows, use the ```WILDFLY_HOME\bin\jboss-cli.bat``` script.
+
+##### Restore the WildFly Standalone Server Configuration Manually 
+When you have completed testing the quickstart, you can restore the original server configuration by manually restoring the configuration file with your backup copy.
+
+1. If it is running, stop the WildFly server.
+
+2. Replace the ```WILDFLY_HOME/standalone/configuration/standalone.xml``` file with the backup copy of the file.

--- a/hash-charset-encoding/configure-elytron.cli
+++ b/hash-charset-encoding/configure-elytron.cli
@@ -1,0 +1,36 @@
+# Batch script to enable Elytron for the quickstart application in the JBoss EAP server
+
+# Start batching commands
+batch
+
+# Configure a filesystem realm with a single identity
+/subsystem=elytron/filesystem-realm=fsRealm:add(path=fs-users, relative-to=jboss.server.config.dir, hash-encoding=hex, hash-charset=KOI8-R)
+/subsystem=elytron/filesystem-realm=fsRealm:add-identity(identity=quickstartUser)
+/subsystem=elytron/filesystem-realm=fsRealm:set-password(digest={algorithm=digest-md5, realm=fsRealm, password=пароль}, identity=quickstartUser)
+
+/subsystem=elytron/filesystem-realm=fsRealm:add-identity-attribute(identity=quickstartUser, name=Roles, value=["Admin", "Guest"])
+
+# Add a simple role decoder
+/subsystem=elytron/simple-role-decoder=from-roles-attribute:add(attribute=Roles)
+
+# Configure a new security domain to use our filesystem realm and role decoder
+/subsystem=elytron/security-domain=fsDomain:add(realms=[{realm=fsRealm, role-decoder=from-roles-attribute}], \
+default-realm=fsRealm,permission-mapper=default-permission-mapper)
+
+# Add the case security domain mapping in the EJB3 subsystem
+/subsystem=ejb3/application-security-domain=other:add(security-domain=fsDomain)
+
+# Update the sasl-authentication-factory to use the fsDomain
+/subsystem=elytron/sasl-authentication-factory=application-sasl-authentication:write-attribute(name=security-domain, value=fsDomain)
+
+# Update the sasl-authentication-factory to use the PLAIN mechanism
+/subsystem=elytron/sasl-authentication-factory=application-sasl-authentication:list-add(name=mechanism-configurations, value={mechanism-name=PLAIN})
+
+# Update the http-remoting-connector to use the application-sasl-authentication factory
+/subsystem=remoting/http-connector=http-remoting-connector:write-attribute(name=sasl-authentication-factory,value=application-sasl-authentication)
+
+# Run the batch commands
+run-batch
+
+# Reload the server configuration
+reload

--- a/hash-charset-encoding/pom.xml
+++ b/hash-charset-encoding/pom.xml
@@ -1,0 +1,79 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wildfly.security.examples</groupId>
+    <artifactId>hash-charset-encoding</artifactId>
+    <version>1.0.0.Alpha1-SNAPSHOT</version>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <version.org.wildfly.wildfly-ejb-client-bom>20.0.0.Final</version.org.wildfly.wildfly-ejb-client-bom>
+        <version.org.wildfly.security.wildfly-elytron>1.16.0.Final</version.org.wildfly.security.wildfly-elytron>
+        <version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.3._spec>2.0.1.Final</version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.3._spec>
+        <version.org.wildfly.plugins.wildfly-maven-plugins>2.0.2.Final</version.org.wildfly.plugins.wildfly-maven-plugins>
+        <version.org.apache.maven.plugins.maven-ejb-plugins>3.2</version.org.apache.maven.plugins.maven-ejb-plugins>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-ejb-client-bom</artifactId>
+            <version>${version.org.wildfly.wildfly-ejb-client-bom}</version>
+            <type>pom</type>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron</artifactId>
+            <version>${version.org.wildfly.security.wildfly-elytron}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.annotation</groupId>
+            <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+            <scope>provided</scope>
+            <version>${version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.3._spec}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.org.wildfly.plugins.wildfly-maven-plugins}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-ejb-plugin</artifactId>
+                <configuration>
+                    <ejbVersion>${version.org.apache.maven.plugins.maven-ejb-plugins}</ejbVersion>
+                    <generateClient>true</generateClient>
+                </configuration>
+            </plugin>
+            <!-- Add the Maven exec plug-in to allow us to run a Java program via Maven -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <configuration>
+                    <executable>java</executable>
+                    <workingDirectory>${project.build.directory}/exec-working-directory</workingDirectory>
+                    <arguments>
+                        <!-- automatically creates the classpath using all project dependencies,
+                                      also adding the project build directory -->
+                        <argument>-classpath</argument>
+                        <classpath></classpath>
+                        <argument>org.wildfly.security.examples.RemoteClient</argument>
+                    </arguments>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/hash-charset-encoding/restore-configuration.cli
+++ b/hash-charset-encoding/restore-configuration.cli
@@ -1,0 +1,33 @@
+# Batch script to restore the JBEAP configuration that was modified to run the quickstart
+
+# Start batching commands
+batch
+
+# Remove the application security domain mapping from the EJB3 subsystem
+/subsystem=ejb3/application-security-domain=other:remove
+
+# Restore the sasl-authentication-factory to use legacy application security domain
+/subsystem=elytron/sasl-authentication-factory=application-sasl-authentication:write-attribute(name=security-domain, value=ApplicationDomain)
+
+# Remove the security domain using the filesystem realm
+/subsystem=elytron/security-domain=fsDomain:remove()
+
+# Remove the simple role decoder
+/subsystem=elytron/simple-role-decoder=from-roles-attribute:remove()
+
+/subsystem=elytron/filesystem-realm=fsRealm:remove-identity(identity=quickstartUser)
+
+# Remove the filesystem realm
+/subsystem=elytron/filesystem-realm=fsRealm:remove()
+
+# Restore the default sasl-authentication-factory configuration by removing the PLAIN mechanism
+/subsystem=elytron/sasl-authentication-factory=application-sasl-authentication:list-remove(name=mechanism-configurations, value={mechanism-name=PLAIN})
+
+# Restore the http-remoting-connector configuration
+/subsystem=remoting/http-connector=http-remoting-connector:undefine-attribute(name=sasl-authentication-factory)
+
+# Run the batch commands
+run-batch
+
+# Reload the server configuration
+reload

--- a/hash-charset-encoding/src/main/java/org/wildfly/security/examples/RemoteClient.java
+++ b/hash-charset-encoding/src/main/java/org/wildfly/security/examples/RemoteClient.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.examples;
+
+
+import java.util.Hashtable;
+
+import javax.ejb.EJBAccessException;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+
+/**
+ * The remote client responsible for making invoking the intermediate bean to demonstrate security context propagation
+ * in EJB to remote EJB calls.
+ *
+ * @author <a href="mailto:sguilhen@redhat.com">Stefan Guilhen</a>
+ */
+public class RemoteClient {
+
+    public static void main(String[] args) throws Exception {
+
+        final Hashtable<String, String> jndiProperties = new Hashtable<>();
+        jndiProperties.put(Context.INITIAL_CONTEXT_FACTORY, "org.wildfly.naming.client.WildFlyInitialContextFactory");
+        jndiProperties.put(Context.PROVIDER_URL, "remote+http://localhost:8080");
+        final Context context = new InitialContext(jndiProperties);
+
+        SecuredEJBRemote reference = (SecuredEJBRemote) context.lookup("ejb:/hash-charset-encoding/SecuredEJB!"
+                + SecuredEJBRemote.class.getName());
+
+        System.out.println("\n\n\n* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *\n\n");
+        System.out.println("Successfully called secured bean, caller principal " + reference.getSecurityInfo());
+        boolean hasAdminPermission = false;
+        try {
+            hasAdminPermission = reference.administrativeMethod();
+        } catch (EJBAccessException e) {
+        }
+        System.out.println("\nPrincipal has admin permission: " + hasAdminPermission);
+        System.out.println("\n\n* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *\n\n\n");
+    }
+
+}

--- a/hash-charset-encoding/src/main/java/org/wildfly/security/examples/SecuredEJB.java
+++ b/hash-charset-encoding/src/main/java/org/wildfly/security/examples/SecuredEJB.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.examples;
+
+import java.security.Principal;
+
+import javax.annotation.Resource;
+import javax.annotation.security.RolesAllowed;
+import javax.ejb.Remote;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateless;
+
+import org.jboss.ejb3.annotation.SecurityDomain;
+
+/**
+ * Simple secured EJB using EJB security annotations
+ *
+ * @author Sherif Makary
+ *
+ */
+/**
+ *
+ * Annotate this EJB for authorization. Allow only those in the "guest" role. For EJB authorization, you must also specify the
+ * security domain. This example uses the "other" security domain which is provided by default in the standalone.xml file.
+ *
+ */
+@Stateless
+@Remote(SecuredEJBRemote.class)
+@RolesAllowed({ "Guest" })
+@SecurityDomain("other")
+public class SecuredEJB implements SecuredEJBRemote {
+
+    // Inject the Session Context
+    @Resource
+    private SessionContext ctx;
+
+    /**
+     * Secured EJB method using security annotations
+     */
+    public String getSecurityInfo() {
+        // Session context injected using the resource annotation
+        Principal principal = ctx.getCallerPrincipal();
+        return principal.toString();
+    }
+
+    @RolesAllowed("Admin")
+    public boolean administrativeMethod() {
+        return true;
+    }
+}

--- a/hash-charset-encoding/src/main/java/org/wildfly/security/examples/SecuredEJBRemote.java
+++ b/hash-charset-encoding/src/main/java/org/wildfly/security/examples/SecuredEJBRemote.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.examples;
+
+
+/**
+ * The interface used to access the SecuredEJB.
+ *
+ * @author <a href="mailto:sguilhen@redhat.com">Stefan Guilhen</a>
+ */
+public interface SecuredEJBRemote {
+
+    /**
+     * @return A String containing the name of the current principal.
+     */
+    String getSecurityInfo();
+
+    boolean administrativeMethod();
+
+}

--- a/hash-charset-encoding/src/main/resources/wildfly-config.xml
+++ b/hash-charset-encoding/src/main/resources/wildfly-config.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="KOI8-R"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2020, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<configuration>
+    <authentication-client xmlns="urn:elytron:client:1.5">
+        <authentication-rules>
+            <rule use-configuration="default-config"/>
+        </authentication-rules>
+        <authentication-configurations>
+            <configuration name="default-config">
+                <set-user-name name="quickstartUser"/>
+                <credentials>
+                    <clear-password password="пароль"/>
+                </credentials>
+                <sasl-mechanism-selector selector="PLAIN"/>
+                <providers>
+                    <use-service-loader />
+                </providers>
+            </configuration>
+        </authentication-configurations>
+    </authentication-client>
+</configuration>


### PR DESCRIPTION
Quickstart to demonstrate how to use new hash-encoding and hash-charset attributes in Elytron Security Realms: https://issues.redhat.com/browse/ELY-2001

Depends on:
Elytron: https://github.com/wildfly-security/wildfly-elytron/pull/1440
WildFly Core: https://github.com/wildfly/wildfly-core/pull/4324
WildFly: https://github.com/wildfly/wildfly/pull/13548

Should remove SNAPSHOT version from pom.xml once PRs above are merged. 