### PR TITLE
Adding a one-way SSL example using SSLv2Hello

### DIFF
--- a/sslv2hello-oneway/README.md
+++ b/sslv2hello-oneway/README.md
@@ -1,0 +1,295 @@
+## sslv2hello-oneway: WildFly Elytron SSL Configuration using SSLv2Hello Example 
+
+ This example demonstrates how to configure a server to enable support for SSLv2Hello messages, 
+ and how to configure clients to send SSLv2Hello messages. 
+
+### Use of the WILDFLY_HOME variable
+
+In the following instructions, replace ``WILDFLY_HOME`` with the actual path to your WildFly installation. 
+
+## Generate a Keystore and Self-signed Certificate 
+
++ Open a terminal and navigate to the server `configuration` directory:
+
+```shell script
+$ cd WILDFLY_HOME/standalone/configuration/
+```
+
++ Create a certificate for your server using the following command:
+```shell script
+$>keytool -genkey -alias localhost -keyalg RSA -sigalg MD5withRSA -keystore server.keystore -storepass secret -keypass secret -validity 9999
+
+What is your first and last name?
+   [Unknown]:  localhost
+What is the name of your organizational unit?
+   [Unknown]:  wildfly
+What is the name of your organization?
+   [Unknown]:  jboss
+What is the name of your City or Locality?
+   [Unknown]:  Raleigh
+What is the name of your State or Province?
+   [Unknown]:  Carolina
+What is the two-letter country code for this unit?
+   [Unknown]:  US
+Is CN=localhost, OU=wildfly, O=jboss, L=Raleigh, ST=Carolina, C=US correct?
+   [no]:  yes
+```
+
+Make sure you enter your desired "hostname" for the `first and last name` field, otherwise you might run into issues while permanently accepting this certificate as an exception in some browsers. Chrome does not currently exhibit this issue.
+
+### Configure the Server
+
+You configure the SSL context by running JBoss CLI commands. For your convenience, this quickstart batches the commands into a `configure-ssl.cli` script provided in the root directory of this example.
+
+#### A note on enabling SSLv2Hello in newer JDK versions
+
+Newer JDK versions have disabled TLSv1. Since we need the TLSv1 protocol to make use of 
+SSLv2Hello, we will walk you through how to re-enable it on the server side. 
+
+1. Access the following file: ``WILDFLY_HOME/bin/standalone.conf``. 
+2. Look for the following line 
+```shell script
+# JAVA_OPTS="$JAVA_OPTS -Djava.security.properties==/path/to/custom/java.security"
+```
+3. Make sure to uncomment it and edit the path to the file ``enabled_tlsv1.properties`` in this example application. 
+Additionally, make sure you use one ``=`` as opposed to two. That way you will not completely 
+override the ``java.security`` file. 
+
+Now you can continue with the rest of the server configuration.
+
++ Start the server with the standalone default profile as follows:
+```shell script
+WILDFLY_HOME/bin/standalone.sh
+```
+
++ Review the `configure-ssl.cli` file in the root of this directory. Comments in the script describe the purpose of each block of commands.
+
++ Open a new terminal, navigate to the root directory of this quickstart, and run the following command, replacing `WILDFLY_HOME` with the path to your server:
+```shell script
+$ WILDFLY_HOME/bin/jboss-cli.sh --connect --file=configure-ssl.cli
+```
+
+NOTE: For Windows, use the `WILDFLY_HOME\bin\jboss-cli.bat` script.
+
+You should see the following result when you run the script:
+
+```shell script
+The batch executed successfully
+process-state: reload-required
+```
+
+#### Test the Server SSL Configuration 
+
+To test the connection to the SSL port of your server instance, open a browser and navigate to
+https://localhost:8443/.
+
+You get the privacy error because the
+server certificate is self-signed. If you need to use a fully signed certificate, you must
+get a PEM file from the Certificate Authority and then import the PEM into the keystore.
+
+#### Configure the Client's Trust Store 
+
+Export the server's certificate to a file by navigating to ``WILDFLY_HOME/standalone/configuration`` and
+running the following command:
+
+```shell script
+keytool -export -alias localhost -keystore server.keystore -file myCert.cer -storepass secret
+
+```
+
+Import the certificate into the client's trust store. Note the following command will create a trust store
+if it does not exist at the location specified.
+
+```shell script
+keytool -import -file myCert.cer -alias localhost -keystore client.keystore -storepass secret
+```
+ 
+You should see the following output next:
+
+
+```shell script
+Owner: CN=localhost, OU=wildfly, O=jboss, L=Raleigh, ST=North Carolina, C=US
+Issuer: CN=localhost, OU=wildfly, O=jboss, L=Raleigh, ST=North Carolina, C=US
+Serial number: 7af5ad9991816bbc
+Valid from: Wed Nov 04 16:15:09 EST 2020 until: Thu Nov 04 16:15:09 EDT 2021
+Certificate fingerprints:
+	 SHA1: 24:6E:96:9A:8B:D2:FF:2B:7B:58:87:84:03:F3:ED:C6:56:8B:96:5B
+	 SHA256: 27:51:F6:7A:F8:51:7D:6E:CB:DA:4A:9A:75:E5:9A:AD:06:88:1B:AE:40:73:7D:D8:E4:4F:22:CA:8E:03:94:37
+Signature algorithm name: SHA256withRSA
+Subject Public Key Algorithm: 2048-bit RSA key
+Version: 3
+
+Extensions:
+
+#1: ObjectId: 2.5.29.14 Criticality=false
+SubjectKeyIdentifier [
+KeyIdentifier [
+0000: FF BA 34 E8 94 94 BE EB   25 B5 C5 4E B3 B2 A4 34  ..4.....%..N...4
+0010: 97 EE A2 24                                        ...$
+]
+]
+
+Trust this certificate? [no]: y
+Certificate was added to keystore
+```
+
+You have now created the client's trustore and imported the server's certificate.
+
+### Configure the Client to use SSLv2Hello Messages
+
+The example application presents a simple client ``Client.java`` which checks the connection
+to the server is successful. To ensure the client uses ``SSLv2Hello`` in its initial
+handshake, we have provided a common configuration framework in
+``wildfly-config.xml``.
+
+Review this file to see how ``SSLv2Hello`` is enabled in the client SSL context along with
+``TLSv1``.
+
+As a final step in configuring the client, update the path to the client's trust store to
+``WILDFLY_HOME/standalone/configuration/client.keystore``.
+
+NOTE: If you are running a newer JDK version, the client already has code in place to re-enable 
+TLSv1. 
+
+#### Build and Deploy the Application
+
+Deploy the application by navigating to the root directory for this example and running 
+the following commands:
+
+```
+cd server
+mvn clean package wildfly:deploy
+```
+
+This deploys the ``server-sslv2hello.war`` to the running instance of the server.
+
+You should see a message in the server log indicating that the archive deployed successfully.
+
+### Run Client 
+
+Run client test that shows the connection was successful. 
+
+```
+cd ../client
+mvn clean install -Dtest=Client
+```
+
+### Verifying the Client Sends SSLv2Hello Messages
+
+In the following section, we will be inspecting the SSL debug logs to ensure the Client Hello messages
+make use of ``SSLv2Hello``. You will need to enable SSL debug logs in your client and server using
+the ``javax.net.debug`` system property as follows:
+
+To run your client with SSL debug logs:
+```shell script
+mvn clean install -Dtest=Client -Djavax.net.debug=ssl,handshake
+```
+
+To run your server with SSL debug logs:
+```shell script
+WILDFLY_HOME/bin/standalone.sh -Djavax.net.debug=ssl,handshake
+```
+
+#### Verifying SSLv2Hello Messages Succeed When SSLv2Hello is Configured on the Server
+
+Run your client.
+
+In your client SSL logs, you should see a ``ClientHello`` message similar to the following:
+
+```shell script
+"ClientHello": {
+  "client version"      : "TLSv1",
+  "random"              : "28 D9 B0 EB 0E A1 5B 07 B6 0D 21 B1 87 F8 42 14 EE 11 6A 11 8B B6 19 7D 2B CF DB B5 B1 A1 43 01",
+  "session id"          : "",
+  "cipher suites"       : "[TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA(0xC00A), TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA(0xC014), TLS_RSA_WITH_AES_256_CBC_SHA(0x0035), TLS_DHE_RSA_WITH_AES_256_CBC_SHA(0x0039), TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA(0xC009), TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA(0xC013), TLS_RSA_WITH_AES_128_CBC_SHA(0x002F), TLS_DHE_RSA_WITH_AES_128_CBC_SHA(0x0033)]",
+  "compression methods" : "00",
+  "extensions"          : [
+    "status_request (5)": {
+      "certificate status type": ocsp
+      "OCSP status request": {
+        "responder_id": <empty>
+        "request extensions": {
+          <empty>
+        }
+      }
+    },
+    "supported_groups (10)": {
+      "versions": [secp256r1, secp384r1, secp521r1, ffdhe2048, ffdhe3072, ffdhe4096, ffdhe6144, ffdhe8192]
+    },
+    "ec_point_formats (11)": {
+      "formats": [uncompressed]
+    },
+    "status_request_v2 (17)": {
+      "cert status request": {
+        "certificate status type": ocsp_multi
+        "OCSP status request": {
+          "responder_id": <empty>
+          "request extensions": {
+            <empty>
+          }
+        }
+      }
+    },
+    "extended_master_secret (23)": {
+      <empty>
+    },
+    "supported_versions (43)": {
+      "versions": [TLSv1, SSLv2Hello]
+    },
+    "renegotiation_info (65,281)": {
+      "renegotiated connection": [<no renegotiated connection>]
+    }
+  ]
+}
+```
+
+
+Notice how ``TLSv1`` and ``SSLv2Hello`` are specified under ``supported_versions``. This triggers
+an ``SSLv2Hello ClientHello``. Your tests should succeed, and you should be able to see the
+negotiated protocol is ``TLSv1`` in both your client and server logs.
+
+#### Verifying SSLv2Hello messages fail when SSLv2Hello is not configured on the server
+
+You can modify your ``server-ssl-context`` to accept only ``TLSv1`` as follows:
+
+```shell script
+/subsystem=elytron/server-ssl-context=qsSSLContext:write-attribute(name=protocols,value=[TLSv1])
+```
+
+Now, run your client.
+You should be able to see a similar ``ClientHello`` as the one in the section above, but you should also see a
+``handshake_failure`` in the log.
+
+Upon reviewing your server log, it should provide more details as to what causes the failure. You should see a
+message similar to the following:
+
+```shell script
+ERROR [stderr] (default I/O-2) javax.net.ssl|ERROR|01 14|default I/O-2|2020-11-05
+14:29:27.677 EST|TransportContext.java:318|Fatal (HANDSHAKE_FAILURE): SSLv2Hello is not enabled (
+14:29:27,678 ERROR [stderr] (default I/O-2) "throwable" : {
+14:29:27,678 ERROR [stderr] (default I/O-2)   javax.net.ssl.SSLHandshakeException: SSLv2Hello is not enabled
+```
+
+Now, you have verified that enabling ``SSLv2Hello`` on the client side triggers an ``SSLv2Hello`` message,
+which if not supported by the server, causes a handshake exception.
+
+### Undeploy the Application 
+
+When you are finished testing the application, follow these steps to undeploy the archive:
+
+1. Make sure you start the WildFly server. 
+2. Open a terminal and navigate to the root directory of this example. 
+3. Type the following commands to undeploy the archive:
+
+```shell script
+cd server
+mvn wildfly:undeploy
+```
+
+### Restore the WildFly Standalone Server Configuration 
+You can restore the original server configuration by running the ``restore-configuration.cli``
+script provided by navigating to the root directory of this application and running: 
+
+```shell script
+WILDFLY_HOME/bin/jboss-cli.sh --connect --file=restore-configuration.cli
+```

--- a/sslv2hello-oneway/client/pom.xml
+++ b/sslv2hello-oneway/client/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>elytron-quickstart</groupId>
+    <version>1.0.0.Alpha1-SNAPSHOT</version>
+    <artifactId>client-sslv2hello</artifactId>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <version.org.wildfly.security.wildfly.elytron>1.16.0.Final</version.org.wildfly.security.wildfly.elytron>
+        <version.org.junit.junit>4.12</version.org.junit.junit>
+        <version.org.jboss.resteasy.resteasy.client>3.13.0.Final</version.org.jboss.resteasy.resteasy.client>
+        <version.org.wildfly.wildfly.client.all>21.0.0.Beta1</version.org.wildfly.wildfly.client.all>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron</artifactId>
+            <version>${version.org.wildfly.security.wildfly.elytron}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${version.org.junit.junit}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client</artifactId>
+            <version>${version.org.jboss.resteasy.resteasy.client}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.wildfly/wildfly-client-all -->
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-client-all</artifactId>
+            <version>${version.org.wildfly.wildfly.client.all}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/sslv2hello-oneway/client/src/main/resources/META-INF/wildfly-config.xml
+++ b/sslv2hello-oneway/client/src/main/resources/META-INF/wildfly-config.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2020, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<configuration>
+    <authentication-client xmlns="urn:elytron:client:1.6">
+        <key-stores>
+            <key-store name="truststore" type="JKS">
+                <file name="PATH/TO/KEYSTORE"/>
+                <key-store-clear-password password="secret"/>
+            </key-store>
+        </key-stores>
+        <ssl-contexts>
+            <ssl-context name="client-context">
+                <trust-store key-store-name="truststore"/>
+                <protocol names="SSLv2Hello TLSv1"/>
+            </ssl-context>
+        </ssl-contexts>
+        <ssl-context-rules>
+            <rule use-ssl-context="client-context"/>
+        </ssl-context-rules>
+    </authentication-client>
+</configuration>

--- a/sslv2hello-oneway/client/src/test/java/Client.java
+++ b/sslv2hello-oneway/client/src/test/java/Client.java
@@ -1,0 +1,62 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.security.Security;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.ws.rs.core.Response;
+
+/**
+ * RESTEasy Client testing successful connection using SSLv2Hello
+ *
+ * @author Sonia Zaldana Calles
+ */
+public class Client {
+
+    public static String disabledAlgorithms;
+
+    @BeforeClass
+    public static void init() {
+        disabledAlgorithms = Security.getProperty("jdk.tls.disabledAlgorithms");
+        if (disabledAlgorithms != null && (disabledAlgorithms.contains("TLSv1") || disabledAlgorithms.contains("TLSv1.1"))) {
+            // reset the disabled algorithms to make sure that the protocols required in this test are available
+            Security.setProperty("jdk.tls.disabledAlgorithms", "");
+        }
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        if (disabledAlgorithms != null) {
+            Security.setProperty("jdk.tls.disabledAlgorithms", disabledAlgorithms);
+        }
+    }
+
+    @Test
+    public void test() {
+        ResteasyClient client = new ResteasyClientBuilder().hostnameVerifier(NoopHostnameVerifier.INSTANCE).build();
+        Response response = client.target("https://127.0.0.1:8443/server-sslv2hello/HelloWorld").request().get();
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getStatus(), 200);
+    }
+}

--- a/sslv2hello-oneway/configure-ssl.cli
+++ b/sslv2hello-oneway/configure-ssl.cli
@@ -1,0 +1,21 @@
+# Batch script to configure server side SSL in the JBoss EAP server
+
+# Start batching commands
+batch
+
+# Add the keystore, key manager and ssl context configuration in the elytron subsystem
+/subsystem=elytron/key-store=qsKeyStore:add(path=server.keystore,relative-to=jboss.server.config.dir,type=JKS,credential-reference={clear-text=secret})
+/subsystem=elytron/key-manager=qsKeyManager:add(key-store=qsKeyStore,credential-reference={clear-text=secret})
+/subsystem=elytron/server-ssl-context=qsSSLContext:add(key-manager=qsKeyManager,protocols=[TLSv1,SSLv2Hello])
+
+# Change the undertow subsystem configuration to use the ssl context defined in the previous step for https
+/subsystem=undertow/server=default-server/https-listener=https:undefine-attribute(name=security-realm)
+/subsystem=undertow/server=default-server/https-listener=https:write-attribute(name=ssl-context,value=qsSSLContext)
+
+# Run the batch commands
+run-batch
+
+# Reload the server configuration
+reload
+
+

--- a/sslv2hello-oneway/enable_tlsv1.properties
+++ b/sslv2hello-oneway/enable_tlsv1.properties
@@ -1,0 +1,2 @@
+jdk.tls.disabledAlgorithms=
+security.useSystemPropertiesFile=false

--- a/sslv2hello-oneway/restore-configuration.cli
+++ b/sslv2hello-oneway/restore-configuration.cli
@@ -1,0 +1,21 @@
+# Batch script to restore the JBoss EAP server configuration
+
+# Start batching commands
+batch
+
+# Revert the changes in the undertow subsystem
+/subsystem=undertow/server=default-server/https-listener=https:undefine-attribute(name=ssl-context)
+/subsystem=undertow/server=default-server/https-listener=https:write-attribute(name=security-realm,value=ApplicationRealm)
+
+# Remove the ssl context, key manager and keystore configuration from the elytron subsystem
+/subsystem=elytron/server-ssl-context=qsSSLContext:remove
+/subsystem=elytron/key-manager=qsKeyManager:remove
+/subsystem=elytron/key-store=qsKeyStore:remove
+
+# Run the batch commands
+run-batch
+
+# Reload the server configuration
+reload
+
+

--- a/sslv2hello-oneway/server/pom.xml
+++ b/sslv2hello-oneway/server/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>elytron-quickstart</groupId>
+    <version>1.0.0.Alpha1-SNAPSHOT</version>
+    <artifactId>server-sslv2hello</artifactId>
+    <packaging>war</packaging>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <version.jakarta.enterprise>2.0.2</version.jakarta.enterprise>
+        <version.org.jboss.spec.javax.servlet>1.0.2.Final</version.org.jboss.spec.javax.servlet>
+        <version.org.jboss.spec.annotation>2.0.1.Final</version.org.jboss.spec.annotation>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <version>${version.jakarta.enterprise}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <version>${version.org.jboss.spec.javax.servlet}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.annotation</groupId>
+            <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+            <version>${version.org.jboss.spec.annotation}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <!-- WildFly plug-in to deploy the WAR. This allows to use mvn wildfly:deploy -->
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>2.0.0.Final</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/sslv2hello-oneway/server/src/main/java/examples/HelloService.java
+++ b/sslv2hello-oneway/server/src/main/java/examples/HelloService.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package examples;
+
+/**
+ * A simple CDI service which is able to say hello to someone
+ *
+ */
+public class HelloService {
+
+    String createHelloMessage(String name) {
+        return "Hello " + name + "!" + " WildFly One SSL is configured and server certificate is verified !!";
+    }
+
+}

--- a/sslv2hello-oneway/server/src/main/java/examples/HelloWorldServlet.java
+++ b/sslv2hello-oneway/server/src/main/java/examples/HelloWorldServlet.java
@@ -1,0 +1,60 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package examples;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import javax.inject.Inject;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * <p>
+ * A simple servlet taking advantage of features added in 3.0.
+ * </p>
+ * <p>
+ * <p>
+ * The servlet is registered and mapped to /HelloWorld using the {@linkplain WebServlet
+ * </p>
+ * @HttpServlet}. The {@link HelloService} is injected by CDI.
+ *
+ */
+@SuppressWarnings("serial")
+@WebServlet("/HelloWorld")
+public class HelloWorldServlet extends HttpServlet {
+
+    static String PAGE_HEADER = "<html><head><title>helloworld</title></head><body>";
+
+    static String PAGE_FOOTER = "</body></html>";
+
+    @Inject
+    HelloService helloService;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("text/html");
+        PrintWriter writer = resp.getWriter();
+        writer.println(PAGE_HEADER);
+        writer.println("<h2>" + helloService.createHelloMessage("World ") + "</h2>");
+        writer.println(PAGE_FOOTER);
+        writer.close();
+    }
+
+}

--- a/sslv2hello-oneway/server/src/main/webapp/WEB-INF/beans.xml
+++ b/sslv2hello-oneway/server/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2020, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!-- Marker file indicating CDI should be enabled -->
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+      http://xmlns.jcp.org/xml/ns/javaee
+      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       bean-discovery-mode="all">
+</beans>

--- a/sslv2hello-oneway/server/src/main/webapp/WEB-INF/web.xml
+++ b/sslv2hello-oneway/server/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,29 @@
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2020, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+
+    <!-- One of the ways of activating REST Servises is adding these lines.
+         The server is responsible for adding the corresponding servlet automatically.
+         The class org.jboss.as.quickstarts.html5rest.HelloWorld class has the
+         annotation @Path("/") to receive the REST invocation -->
+    <servlet-mapping>
+        <servlet-name>javax.ws.rs.core.Application</servlet-name>
+        <url-pattern>/hello/*</url-pattern>
+    </servlet-mapping>
+</web-app>

--- a/sslv2hello-oneway/server/src/main/webapp/index.html
+++ b/sslv2hello-oneway/server/src/main/webapp/index.html
@@ -1,0 +1,34 @@
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2020, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<html>
+    <head><title>One Way SSL using SSLv2Hello</title></head>
+
+    <body>
+    	<p>
+    	  This example demonstrates how to configure a server that accepts SSLv2Hello messages, as well as how to
+            configure a client that sends SSLv2Hello messages.
+    	</p>
+    	<p>
+    	 There is no user interface for this quickstart.
+         Instead, you can verify the REST endpoint is up and running by accessing the following URL:
+         </p>
+         <div style="margin-left: 1em;">
+         <a href="server-sslv2hello/HelloWorld">server-sslv2hello/HelloWorld</a>
+         </div>
+    </body>
+
+</html>


### PR DESCRIPTION
Quickstart to demonstrate how to enable support for SSLv2Hello in Elytron: https://issues.redhat.com/browse/EAP7-1542

Depends on:
WildFly Elytron: https://github.com/wildfly-security/wildfly-elytron/pull/1458
WildFly Core: https://github.com/wildfly/wildfly-core/pull/4377
WildFly: https://github.com/wildfly/wildfly/pull/13673

Should remove SNAPSHOT version from pom.xml once PRs above are merged.