### PR TITLE
Migrate self-service example to Jakarta EE10

### DIFF
--- a/self-service/README.md
+++ b/self-service/README.md
@@ -19,8 +19,12 @@ mvn clean package install wildfly:deploy
 
 To login: **jane** with password **passwordJane**
 
-### To restore wildfly to its initial configuration you can use restore.cli file:
+### To restore wildfly to its initial configuration
+
+Undeploy the package, then you can use restore.cli file:
+
 ```
+mvn wildfly:undeploy
 {path_to_wildfly}/bin/jboss-cli.sh --connect --file=restore.cli (this will restore previous changes to server)
 ```
 

--- a/self-service/pom.xml
+++ b/self-service/pom.xml
@@ -9,28 +9,39 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>war</packaging>
 
-    <dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-ee-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
+    <dependencies>
         <dependency>
-            <groupId>org.jboss.spec.javax.ws.rs</groupId>
-            <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
-            <version>1.0.2.Final</version>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.annotation</groupId>
-            <artifactId>jboss-annotations-api_1.2_spec</artifactId>
-            <version>1.0.2.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-elytron</artifactId>
-            <version>1.19.0.Final</version>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.json/json -->
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20180813</version>
+            <version>${version.org.json.json}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron</artifactId>
+            <version>${version.org.wildfly.security.wildfly-elytron}</version>
         </dependency>
     </dependencies>
 
@@ -41,13 +52,13 @@
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-maven-plugin</artifactId>
-                <version>2.0.0.Final</version>
+                <version>${version.wildfly-maven-plugin}</version>
             </plugin>
 
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>${frontend-maven-plugin.version}</version>
+                <version>${version.frontend-maven-plugin}</version>
 
                 <configuration>
                     <nodeVersion>${node.version}</nodeVersion>
@@ -89,7 +100,7 @@
 
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>${version.maven-resources-plugin}</version>
                 <executions>
                     <execution>
                         <id>position-react-build</id>
@@ -113,11 +124,18 @@
     </build>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <frontendSrcDir>${project.basedir}/src/main/frontend</frontendSrcDir>
         <node.version>v10.13.0</node.version>
         <yarn.version>v1.12.3</yarn.version>
-        <frontend-maven-plugin.version>1.6</frontend-maven-plugin.version>
+
+        <version.org.json.json>20220924</version.org.json.json>
+        <version.org.wildfly.security.wildfly-elytron>2.0.0.Final</version.org.wildfly.security.wildfly-elytron>
+        <version.server.bom>27.0.1.Final</version.server.bom>
+
+        <version.frontend-maven-plugin>1.12.1</version.frontend-maven-plugin>
+        <version.maven-resources-plugin>3.3.0</version.maven-resources-plugin>
+        <version.wildfly-maven-plugin>4.0.0.Final</version.wildfly-maven-plugin>
     </properties>
 </project>

--- a/self-service/src/main/java/Identity.java
+++ b/self-service/src/main/java/Identity.java
@@ -14,14 +14,26 @@
  * limitations under the License.
  */
 
-import javax.annotation.security.PermitAll;
-import javax.annotation.security.RolesAllowed;
-import javax.ws.rs.*;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.SecurityContext;
-import java.util.*;
+import static org.wildfly.security.authz.RoleDecoder.KEY_ROLES;
+import static org.wildfly.security.password.interfaces.ClearPassword.ALGORITHM_CLEAR;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.SecurityContext;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -37,9 +49,6 @@ import org.wildfly.security.credential.Credential;
 import org.wildfly.security.credential.PasswordCredential;
 import org.wildfly.security.password.PasswordFactory;
 import org.wildfly.security.password.spec.ClearPasswordSpec;
-
-import static org.wildfly.security.authz.RoleDecoder.KEY_ROLES;
-import static org.wildfly.security.password.interfaces.ClearPassword.ALGORITHM_CLEAR;
 
 @PermitAll
 @Path("/")

--- a/self-service/src/main/java/JAXActivator.java
+++ b/self-service/src/main/java/JAXActivator.java
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import javax.ws.rs.ApplicationPath;
-import javax.ws.rs.core.Application;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
 
 /**
- * JAXActivator is an arbitrary name, what is important is that javax.ws.rs.core.Application is extended
+ * JAXActivator is an arbitrary name, what is important is that jakarta.ws.rs.core.Application is extended
  * and the @ApplicationPath annotation is used with a "rest" path.  Without this the rest routes linked to
  * from index.html would not be found.
  */


### PR DESCRIPTION
Migrate self-service example to EE10. Also updated restoration instructions in README to undeploy the package.
