### PR TITLE
Resolves #122 Update tp Jakarta EE 10 and WildFly 27.0.1.Final.

### DIFF
--- a/client-default-ssl-context-provider/client/pom.xml
+++ b/client-default-ssl-context-provider/client/pom.xml
@@ -3,38 +3,36 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>elytron-quickstart</groupId>
-    <version>2.0.0.Alpha1-SNAPSHOT</version>
-    <artifactId>client</artifactId>
+    
+    <parent>
+        <groupId>org.wildfly.security.examples</groupId>
+        <artifactId>client-default-ssl-context-parent</artifactId>
+        <version>2.0.0.Alpha1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>client-default-ssl-context-client</artifactId>
     <packaging>jar</packaging>
-    <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-    </properties>
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>3.14.0.Final</version>
             <scope>test</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.wildfly/wildfly-client-all -->
         <dependency>
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-client</artifactId>
-            <version>1.19.0.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.wildfly.client</groupId>
             <artifactId>wildfly-client-config</artifactId>
-            <version>1.0.1.Final</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/client-default-ssl-context-provider/client/src/test/java/Client.java
+++ b/client-default-ssl-context-provider/client/src/test/java/Client.java
@@ -1,13 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.security.NoSuchAlgorithmException;
+import java.security.Security;
+
+import javax.net.ssl.SSLContext;
+
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
 import org.junit.Assert;
 import org.junit.Test;
 import org.wildfly.security.auth.client.WildFlyElytronClientDefaultSSLContextProvider;
 
-import javax.net.ssl.SSLContext;
-import javax.ws.rs.core.Response;
-import java.security.NoSuchAlgorithmException;
-import java.security.Security;
+import jakarta.ws.rs.core.Response;
 
 /**
  * Client test method demonstrating how WildFlyElytronClientDefaultSSLContextProvider can be used to register JVM wide default client SSLContext.
@@ -19,7 +40,7 @@ public class Client {
     @Test
     public void test() throws NoSuchAlgorithmException {
         Security.insertProviderAt(new WildFlyElytronClientDefaultSSLContextProvider("src/test/wildfly-config-two-way-tls.xml"), 1);
-        ResteasyClient client = new ResteasyClientBuilder().sslContext(SSLContext.getDefault()).hostnameVerification(ResteasyClientBuilder.HostnameVerificationPolicy.ANY).build();
+        ResteasyClient client = new ResteasyClientBuilderImpl().sslContext(SSLContext.getDefault()).hostnameVerification(ResteasyClientBuilder.HostnameVerificationPolicy.ANY).build();
         Response response = client
                 .target("https://127.0.0.1:8443/client-default-ssl-context-provider/rest/hello")
                 .request().get();

--- a/client-default-ssl-context-provider/pom.xml
+++ b/client-default-ssl-context-provider/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.wildfly.security.examples</groupId>
+    <version>2.0.0.Alpha1-SNAPSHOT</version>
+    <artifactId>client-default-ssl-context-parent</artifactId>
+
+    <packaging>pom</packaging>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        
+        <version.wildfly>27.0.1.Final</version.wildfly>
+    </properties>
+    
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-ee-with-tools</artifactId>
+                <scope>import</scope>
+                <type>pom</type>
+                <version>${version.wildfly}</version>
+            </dependency>
+
+            <!-- Project Dependecy -->
+            <dependency>
+                <groupId>org.wildfly.security.examples</groupId>
+                <artifactId>client-default-ssl-context-parent</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <modules>
+        <module>client</module>
+        <module>server</module>
+    </modules>
+
+</project>

--- a/client-default-ssl-context-provider/server/pom.xml
+++ b/client-default-ssl-context-provider/server/pom.xml
@@ -3,21 +3,22 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>elytron-quickstart</groupId>
-    <version>2.0.0.Alpha1-SNAPSHOT</version>
-    <artifactId>client-default-ssl-context-provider</artifactId>
-    <packaging>war</packaging>
 
-    <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-    </properties>
+    <parent>
+        <groupId>org.wildfly.security.examples</groupId>
+        <artifactId>client-default-ssl-context-parent</artifactId>
+        <version>2.0.0.Alpha1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>client-default-ssl-context-endpoint</artifactId>
+
+    <packaging>war</packaging>
 
     <dependencies>
         <dependency>
-            <groupId>org.jboss.spec.javax.ws.rs</groupId>
-            <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
-            <version>1.0.2.Final</version>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
     </dependencies>
 
@@ -27,7 +28,6 @@
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-maven-plugin</artifactId>
-                <version>2.0.0.Final</version>
             </plugin>
         </plugins>
     </build>

--- a/client-default-ssl-context-provider/server/src/main/java/org/wildfly/elytron/resteasy/client/example/HelloUser.java
+++ b/client-default-ssl-context-provider/server/src/main/java/org/wildfly/elytron/resteasy/client/example/HelloUser.java
@@ -15,8 +15,8 @@
  */
 package org.wildfly.elytron.resteasy.client.example;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
 
 /**
  * Simple REST endpoint that you can access after accepting server's certificate and providing client's certificate.

--- a/client-default-ssl-context-provider/server/src/main/java/org/wildfly/elytron/resteasy/client/example/JAXActivator.java
+++ b/client-default-ssl-context-provider/server/src/main/java/org/wildfly/elytron/resteasy/client/example/JAXActivator.java
@@ -15,8 +15,8 @@
  */
 package org.wildfly.elytron.resteasy.client.example;
 
-import javax.ws.rs.ApplicationPath;
-import javax.ws.rs.core.Application;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
 
 /**
  * JAXActivator is an arbitrary name, what is important is that javax.ws.rs.core.Application is extended


### PR DESCRIPTION
Also adjust artifact hierarcy to show better in Eclipse.

I haven't tested this with the SSL settings but have it deploying and the client side correctly failing that it can't obtain the SSLContext (because I haven't set it up).

In some of our blogs we have just used simple-webapp and described the step in the blog, I am wondering if in this area the examples should just have a simple-restful-ws example but also in the examples or incubator have a tool to do all the SSL configuration.

We do have some automation in the CLI but the problem with CLI automation is it is tied to a specific client so we can't re-use with direct management access or the admin console.