### PR TITLE
Resolves #126 Adjust dependencies to align with WildFly 27.0.1.Final

### DIFF
--- a/custom-principal-transformer/README.md
+++ b/custom-principal-transformer/README.md
@@ -13,7 +13,7 @@ Compile:
 Add a module that contains our custom principal transformer to WildFly:
 
         bin/jboss-cli.sh
-        module add --name=org.wildfly.security.examples.custom-principal-transformer --resources=/PATH_TO_ELYTRON_EXAMPLES/elytron-examples/custom-principal-transformer/target/custom-principal-transformer-1.0.0.Alpha1-SNAPSHOT.jar --dependencies=org.wildfly.security.elytron,org.wildfly.extension.elytron
+        module add --name=org.wildfly.security.examples.custom-principal-transformer --resources=/PATH_TO_ELYTRON_EXAMPLES/elytron-examples/custom-principal-transformer/target/custom-principal-transformer-2.0.0.Alpha1-SNAPSHOT.jar --dependencies=org.wildfly.security.elytron,org.wildfly.extension.elytron
 
 Add a ```custom-principal-transformer``` in the Elytron subsystem that references this new module and our custom principal transformer class that is contained in this module:
 

--- a/custom-principal-transformer/pom.xml
+++ b/custom-principal-transformer/pom.xml
@@ -11,15 +11,27 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <version.org.wildfly.security.wildfly-elytron>1.8.0.Final</version.org.wildfly.security.wildfly-elytron>
-        <version.org.wildfly.core>7.0.0.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>19.0.1.Final</version.org.wildfly.core>
+        <version.wildfly>27.0.1.Final</version.wildfly>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-ee-with-tools</artifactId>
+                <scope>import</scope>
+                <type>pom</type>
+                <version>${version.wildfly}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron</artifactId>
-            <version>${version.org.wildfly.security.wildfly-elytron}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>


### PR DESCRIPTION
The subsystem dependency is not available from the poms so still needs to be manually specified.