### PR TITLE
Add custom principal examples

### DIFF
--- a/custom-principal-ee/README.md
+++ b/custom-principal-ee/README.md
@@ -1,0 +1,220 @@
+# Using custom principals with Jakarta Security
+
+This example demonstrates how to use custom principals with Jakarta Security. The server uses a
+custom Elytron transformer to create the custom principal. When a client is authenticated, the
+principal is injected into the Servlet using the Jakarta `SecurityContext` class and the
+Elytron `SecurityDomain` class. The client can then retrieve the principal using either of these
+classes.
+
+This demo is based on the [custom-principal-transformer](../custom-principal-transformer) example,
+and the [WildFly ee-security](https://github.com/wildfly/quickstart/tree/main/ee-security)
+quickstart. For more information on how principal transformers work,
+see [this blog post](http://darranl.blogspot.com/2017/07/wildfly-elytron-principal-transformers.html).
+
+## Usage
+
+### Use of WILDFLY_HOME
+
+In the following instructions, replace `WILDFLY_HOME` with the actual path to your WildFly
+installation.
+
+## Back up the WildFly Standalone Server Configuration
+
+Before you begin, back up your server configuration file.
+
+1. If it is running, stop the WildFly server.
+2. Back up the `WILDFLY_HOME/standalone/configuration/standalone.xml` file.
+
+After you have completed testing this example, you can replace this file to restore the server to
+its original configuration.
+
+### Start the WildFly Server
+
+First, clone the `elytron-examples` repo locally:
+
+```shell
+$ git clone https://github.com/wildfly-security-incubator/elytron-examples
+$ cd elytron-examples
+```
+
+Then, start the server:
+
+```shell
+$ WILDFLY_HOME/bin/standalone.sh
+```
+
+### Build the Demo App
+
+1. Make sure you start the WildFly server as described above.
+2. Open a new terminal and navigate to the root directory of this example.
+3. Type the following command to build the artifacts. A WAR will be exported
+   to `custom-principal-ee/application/target`, and a JAR will be exported
+   to  `custom-principal-ee/components/target`.
+
+```shell
+$ mvn clean install
+```
+
+### Configure Elytron
+
+#### Deploy custom principal and transformers
+
+Review the `configure-elytron.cli` file in the root of this example directory. This quickstart
+includes two Maven modules, and the CLI script performs a number of operations on the `components`
+module, which contains our custom principal:
+
+1. The `custom-principal-ee-components` archive is added as a module to the server. This allows the
+   custom components to be used by the server.
+2. A default JACC (Jakarta Authorization) policy is created, allowing deployments to use
+   the `SecurityContext` interface from the Jakarta Security API to access the authorized identity.
+3. A new security domain is created, and the `application-security-domain` mapping in the Undertow
+   subsystem is updated to reference this security domain.
+4. The `integrated-jaspi` attribute for the `application-security-domain` is disabled, to allow
+   ad-hoc identities to be created dynamically.
+
+In the `configure-elytron.cli` script, replace `/PATH/TO` with the parent directory of
+the `elytron-examples` repo. Then, open a new terminal, navigate to the root directory of this
+example and run the following command, replacing `WILDFLY_HOME` with the path to your server.
+
+```shell
+$ WILDFLY_HOME/bin/jboss-cli.sh --connect --file=configure-elytron.cli
+```
+
+> NOTE: For Windows, use the `WILDFLY_HOME\bin\jboss-cli.bat` script.
+
+You should see the following result when you run the script:
+
+```shell
+The batch executed successfully
+process-state: reload-required
+```
+
+#### Deploy the Web App
+
+Next, deploy the web app, built from the `custom-principal-ee-application` module, to the server:
+
+1. Open a terminal and navigate to the root directory of this quickstart.
+2. Type the following command to deploy the web app to the server.
+
+```shell
+$ mvn wildfly:deploy
+```
+
+This deploys the `custom-principal-ee/application/target/custom-principal-ee.war` to the running
+instance of the server. You should see a message in the server log indicating that the archive
+deployed successfully.
+
+### Access the Application
+
+The web app will be running at `http://localhost:8080/custom-principal-ee`. To see and manipulate
+the HTTP headers within the HTTP requests, it is recommended to use a client like `curl` to invoke
+the servlet.
+
+Open a terminal, and attempt to access the secured page. It will return a `401 Unauthorized` error.:
+
+```shell
+$ curl -v http://localhost:8080/custom-principal-ee/secured
+
+[...]
+< HTTP/1.1 401 Unauthorized
+< Expires: 0
+< Connection: keep-alive
+< WWW-Authenticate: Basic realm="principalRealm"
+< Cache-Control: no-cache, no-store, must-revalidate
+< Pragma: no-cache
+< Content-Type: text/html;charset=UTF-8
+< Content-Length: 71
+< Date: Fri, 13 Jan 2023 21:21:07 GMT
+<
+<html><head><title>Error</title></head><body>Unauthorized</body></html>
+```
+
+Now, access the page as a user, by using the `Authorization` header. The BASIC authentication shown
+below uses the Base64 encoding of `quickstartUser:password123!`:
+
+```shell
+$ curl -v http://localhost:8080/custom-principal-ee/secured -H "Authorization: Basic cXVpY2tzdGFydFVzZXI6cGFzc3dvcmQxMjMh"
+
+[...]
+< HTTP/1.1 200 OK
+< Expires: 0
+< Connection: keep-alive
+< Cache-Control: no-cache, no-store, must-revalidate
+[...]
+<!DOCTYPE html>
+<html>
+    <head><title>SecuredServlet - doGet()</title></head>
+    <body>
+        <h1>Custom Principal - Elytron Demo</h1>
+        <p>For reference, transform sequence is quickstartUser -> <em>customQuickstartUserPre</em> -> customQuickstartUserPost -> customQuickstartUserFinal.</p>
+        <p>Injection check - these values should match:</p>
+        <ul>
+            <li>Identity as available from Jakarta Security (<code>SecurityContext</code>): <strong>customQuickstartUserPre</strong></li>
+            <li>Identity as available from injection (<code>SecurityIdentity</code>): <strong>customQuickstartUserPre</strong></li>
+            <li>Identity as provided in HTTPServletRequest: <strong>customQuickstartUserPre</strong></li>
+        </ul>
+        <p>Custom Principal check - these values should match:</p>
+        <ul>
+            <li>Caller principal<code>(SecurityContext.getCallerPrincipal)</code>: Class -> <strong>org.wildfly.security.examples.CustomPrincipal</strong>, Name -> <strong>customQuickstartUserPre</strong></li>
+            <li>Custom principal<code>(SecurityContext.getPrincipalsByType)</code>: Class -> <strong>org.wildfly.security.examples.CustomPrincipal</strong>, Name -> <strong>customQuickstartUserPre</strong></li>
+            <li>Injection<code>(SecurityIdentity.getPrincipal)</code>: Class -> <strong>org.wildfly.security.examples.CustomPrincipal</strong>, Name -> <strong>customQuickstartUserPre</strong></li>
+        </ul>
+        <p>Custom Principal usage - this check will return a result of <em>enabled</em> if the CustomPrincipal was injected properly:</p>
+        <ul>
+            <li>SecurityContext reports last login <strong>was 10 days ago</strong>. Secrets access is <strong>enabled</strong>.</li>
+            <li>SecurityIdentity reports last login <strong>was 10 days ago</strong>. Secrets access is <strong>enabled</strong>.</li>
+    </body>
+</html>
+```
+
+### Understanding the Console Output
+
+When the client accesses the secured servlet,
+the [CustomAuthenticationMechanism](./application/src/main/java/org/wildfly/security/examples/CustomAuthenticationMechanism.java)
+passes the BASIC authentication credential to
+the [CustomIdentityStore](./application/src/main/java/org/wildfly/security/examples/CustomIdentityStore.java),
+forming a basic Jakarta Security implementation. If the credential is authenticated, a principal
+transformer is used to create an instance of
+the [CustomPrincipal](./components/src/main/java/org/wildfly/security/examples/CustomPrincipal.java),
+before notifying the container of the login. _(NOTE: the use of a custom `PrincipalTransformer`
+implementation is not required; the transformation can be done directly from
+the `CustomAuthenticationMechanism` if desired.)_
+
+This principal is then made available to Elytron and Jakarta Security classes, which are injected
+into the servlet. When the servlet is invoked, the custom principal `customQuickstartUser` can be
+used to perform class-specific operations. In this example, it retrieves the current and last login
+date, to determine if the client can still access secrets.
+
+### Undeploy the Quickstart
+
+1. Make sure you start the WildFly server.
+2. Open a terminal to the root directory of this quickstart.
+3. Type this command to undeploy the archive:
+
+```$xslt
+$ mvn wildfly:undeploy
+```
+
+### Undeploy the App and Restore the WildFly Standalone Server Configuration
+
+You can restore the original server configuration by undeploying the web app, and running
+the `restore-configuration.cli` script provided in the root directory of this example. Perform the
+following steps to restore the original configuration:
+
+1. Start the WildFly server.
+2. Open a new terminal, navigate to the root directory of this example, and run the following
+   commands:
+
+```shell
+$ mvn wildfly:undeploy
+$ WILDFLY_HOME/bin/jboss-cli.sh --connect --file=restore-configuration.cli
+```
+
+> NOTE: For Windows, use the ```WILDFLY_HOME\bin\jboss-cli.bat``` script.
+
+You should see the following output when you run the script:
+
+```shell
+The batch executed successfully
+process-state: reload-required
+```

--- a/custom-principal-ee/application/pom.xml
+++ b/custom-principal-ee/application/pom.xml
@@ -1,0 +1,70 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.security.examples</groupId>
+        <artifactId>custom-principal-ee</artifactId>
+        <version>2.0.0.Alpha1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>custom-principal-ee-application</artifactId>
+    <version>2.0.0.Alpha1-SNAPSHOT</version>
+    <packaging>war</packaging>
+
+    <properties>
+        <version.io.undertow>2.3.5.Final</version.io.undertow>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wildfly.security.examples</groupId>
+            <artifactId>custom-principal-ee-components</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-elytron-integration</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-auth-server</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.undertow</groupId>
+            <artifactId>undertow-servlet</artifactId>
+            <version>${version.io.undertow}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.security.enterprise</groupId>
+            <artifactId>jakarta.security.enterprise-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.parent.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/custom-principal-ee/application/src/main/java/org/wildfly/security/examples/CustomAuthenticationMechanism.java
+++ b/custom-principal-ee/application/src/main/java/org/wildfly/security/examples/CustomAuthenticationMechanism.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.examples;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.AuthenticationException;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.security.enterprise.credential.BasicAuthenticationCredential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult.Status;
+import jakarta.security.enterprise.identitystore.IdentityStoreHandler;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * A simple {@link HttpAuthenticationMechanism} for testing.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ * @author <a href="mailto:carodrig@redhat.com">Cameron Rodriguez</a>
+ */
+@ApplicationScoped
+public class CustomAuthenticationMechanism implements HttpAuthenticationMechanism {
+
+    private static final String BASIC_REQUEST_HEADER = "Authorization";
+    private static final String BASIC_RESPONSE_HEADER = "WWW-Authenticate";
+    private static final String BASIC_RESPONSE = "Basic realm=\"principalRealm\"";
+
+    @Inject
+    private IdentityStoreHandler identityStoreHandler;
+
+    @Override
+    public AuthenticationStatus validateRequest(HttpServletRequest request, HttpServletResponse response,
+                                                HttpMessageContext httpMessageContext) throws AuthenticationException {
+
+        String basicHeader = request.getHeader(BASIC_REQUEST_HEADER);
+
+        if(basicHeader != null) {
+            BasicAuthenticationCredential credential = new BasicAuthenticationCredential(basicHeader.substring(6));
+            CredentialValidationResult cvr = identityStoreHandler.validate(credential);
+
+            if (cvr.getStatus() == Status.VALID) {
+                return httpMessageContext.notifyContainerAboutLogin(
+                        new CustomTransformer().apply(cvr.getCallerPrincipal()),
+                        cvr.getCallerGroups()
+                );
+            } else {
+                return challenge(response, httpMessageContext);
+            }
+        }
+
+        return challenge(response, httpMessageContext);
+    }
+
+    private static AuthenticationStatus challenge(HttpServletResponse response, HttpMessageContext httpMessageContext) {
+        response.addHeader(BASIC_RESPONSE_HEADER, BASIC_RESPONSE);
+
+        return httpMessageContext.responseUnauthorized();
+    }
+}
+

--- a/custom-principal-ee/application/src/main/java/org/wildfly/security/examples/CustomIdentityStore.java
+++ b/custom-principal-ee/application/src/main/java/org/wildfly/security/examples/CustomIdentityStore.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.examples;
+
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.credential.BasicAuthenticationCredential;
+import jakarta.security.enterprise.credential.Credential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.IdentityStore;
+
+import org.wildfly.security.auth.server.SecurityDomain;
+
+/**
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ * @author <a href="mailto:carodrig@redhat.com">Cameron Rodriguez</a>
+ */
+@ApplicationScoped
+public class CustomIdentityStore implements IdentityStore {
+
+    private static final Map<String, User> USERS;
+
+    static {
+        Map<String, User> users = new HashMap<>();
+        User user = new User("quickstartUser", "password123!".toCharArray(), "Login");
+        users.put(user.getUserName(), user);
+        USERS = Collections.unmodifiableMap(users);
+    }
+
+    @Inject
+    private SecurityDomain securityDomain;
+
+    @Override
+    public CredentialValidationResult validate(Credential credential) {
+        if (credential instanceof BasicAuthenticationCredential) {
+            BasicAuthenticationCredential bac = (BasicAuthenticationCredential) credential;
+
+            User candidate = USERS.get(bac.getCaller());
+            if (candidate != null && Arrays.equals(candidate.getPassword(), bac.getPassword().getValue())) {
+                return new CredentialValidationResult(candidate.getUserName(), candidate.getGroups());
+            }
+        }
+
+        return INVALID_RESULT;
+    }
+
+    private static class User {
+
+        private final String userName;
+        private final char[] password;
+        private final Set<String> groups;
+
+        User(final String userName, final char[] password, final String... roles) {
+            this.userName = userName;
+            this.password = password;
+            groups = new HashSet<>(Arrays.asList(roles));
+        }
+
+        public String getUserName() {
+            return userName;
+        }
+
+        public char[] getPassword() {
+            return password;
+        }
+
+        public Set<String> getGroups() {
+            return groups;
+        }
+
+    }
+}

--- a/custom-principal-ee/application/src/main/java/org/wildfly/security/examples/SecuredServlet.java
+++ b/custom-principal-ee/application/src/main/java/org/wildfly/security/examples/SecuredServlet.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.examples;
+
+import static java.time.temporal.ChronoUnit.DAYS;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Set;
+
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.SecurityContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.wildfly.security.auth.server.SecurityIdentity;
+
+/**
+ * A simple secured HTTP servlet.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ * @author <a href="mailto:carodrig@redhat.com">Cameron Rodriguez</a>
+ */
+@WebServlet(value="/secured")
+public class SecuredServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 4283238124209606350L;
+    @Inject
+    private SecurityContext securityContext;
+    @Inject
+    private SecurityIdentity securityIdentity;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        try (PrintWriter pw = resp.getWriter()) {
+            pw.print(securedPage(req));
+        }
+    }
+
+    private String securedPage(HttpServletRequest req) {
+        String newline = System.getProperty("line.separator");
+        CustomPrincipal customPrincipalFromType = retrieveCustomPrincipal();
+
+        return String.join(newline,
+                "<!DOCTYPE html>",
+                "<html>",
+                "    <head><title>SecuredServlet - doGet()</title></head>",
+                "    <body>",
+                "        <h1>Custom Principal - EE Demo</h1>",
+                "        <p>For reference, transform sequence is quickstartUser -> <em>customQuickstartUserPre</em> -> customQuickstartUserPost -> customQuickstartUserFinal.</p>",
+                "        <p>Injection check - these values should match:</p>",
+                "        <ul>",
+                String.format("            <li>Identity as available from Jakarta Security (<code>SecurityContext</code>): <strong>%s</strong></li>", securityContext.getCallerPrincipal().getName()),
+                String.format("            <li>Identity as available from injection (<code>SecurityIdentity</code>): <strong>%s</strong></li>", securityIdentity.getPrincipal().getName()),
+                String.format("            <li>Identity as provided in HTTPServletRequest: <strong>%s</strong>", req.getUserPrincipal()),
+                "        </ul>",
+                "        <p>Custom Principal check - these values should match:</p>",
+                "        <ul>",
+                String.format("            <li>Caller principal<code>(SecurityContext.getCallerPrincipal)</code>: Class -> <strong>%s</strong>, Name -> <strong>%s</strong></li>",
+                        securityContext.getCallerPrincipal().getClass().getCanonicalName(),
+                        securityContext.getCallerPrincipal().getName()),
+                customPrincipalFromType != null
+                        ? String.format("            <li>Custom principal<code>(SecurityContext.getPrincipalsByType)</code>: Class -> <strong>%s</strong>, Name -> <strong>%s</strong></li>",
+                        customPrincipalFromType.getClass().getCanonicalName(),
+                        customPrincipalFromType.getName())
+                        : String.format("            <li>Custom principal<code>(SecurityContext.getPrincipalsByType)</code>: Class -> <strong>%s</strong>, Name -> <strong>%s</strong></li>",
+                        "not found",
+                        "null"),
+                String.format("            <li>Injection<code>(SecurityIdentity.getPrincipal)</code>: Class -> <strong>%s</strong>, Name -> <strong>%s</strong></li>",
+                        securityIdentity.getPrincipal().getClass().getCanonicalName(),
+                        securityIdentity.getPrincipal().getName()),
+                "        </ul>",
+                "        <p>Custom Principal usage - this check will return a result of <em>enabled</em> if the CustomPrincipal was injected properly:</p>",
+                "        <ul>",
+                customPrincipalFromType != null
+                        ? generateSecretsAccessString("SecurityContext", daysSinceLogin(customPrincipalFromType))
+                        : "        <li>The custom principal was not loaded from SecurityContext. Secrets access is <strong>disabled</strong>.</li>",
+                securityIdentity.getPrincipal().getClass() == CustomPrincipal.class
+                        ? generateSecretsAccessString("SecurityIdentity", daysSinceLogin((CustomPrincipal) securityIdentity.getPrincipal()))
+                        : "        <li>The custom principal was not loaded from SecurityIdentity. Secrets access is <strong>disabled</strong>.</li>",
+                "    </body>",
+                "</html>"
+        );
+    }
+
+    private CustomPrincipal retrieveCustomPrincipal() {
+        Set<CustomPrincipal> customPrincipals = securityContext.getPrincipalsByType(CustomPrincipal.class);
+        return customPrincipals.size() == 1 ? customPrincipals.iterator().next() : null;
+    }
+
+    /** @param principalProvider Name of the class or provider that returned the custom principal. */
+    private String generateSecretsAccessString(String principalProvider, long days) {
+        return String.format("        <li>%s reports last login <strong>%s</strong>. Secrets access is <strong>%s</strong>.</li>",
+                principalProvider,
+                (days != -1 ? String.format("was %d days ago", days) : "is not applicable"),
+                (days < 30 ? "enabled" : "disabled"));
+    }
+
+    public long daysSinceLogin(CustomPrincipal customPrincipal) {
+        if (customPrincipal != null) {
+            if (customPrincipal.getLastLoginTime().equals(customPrincipal.getCurrentLoginTime())) {
+                return -1;
+            } else {
+                return DAYS.between(customPrincipal.getLastLoginTime(), customPrincipal.getCurrentLoginTime());
+            }
+        } else return -1;
+    }
+}

--- a/custom-principal-ee/application/src/main/java/org/wildfly/security/examples/SecurityFactory.java
+++ b/custom-principal-ee/application/src/main/java/org/wildfly/security/examples/SecurityFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.examples;
+
+import java.io.Serializable;
+
+import jakarta.enterprise.context.SessionScoped;
+import jakarta.enterprise.inject.Produces;
+
+import org.wildfly.security.auth.server.SecurityDomain;
+import org.wildfly.security.auth.server.SecurityIdentity;
+
+/**
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ * @author <a href="mailto:carodrig@redhat.com">Cameron Rodriguez</a>
+ */
+@SessionScoped
+public class SecurityFactory implements Serializable {
+
+    private static final long serialVersionUID = 7484045912648260117L;
+
+    @Produces
+    public SecurityDomain getSecurityDomain() {
+        return SecurityDomain.getCurrent();
+    }
+
+    @Produces
+    public SecurityIdentity getSecurityIdentity(SecurityDomain securityDomain) {
+        return securityDomain.getCurrentSecurityIdentity();
+    }
+}

--- a/custom-principal-ee/application/src/main/webapp/WEB-INF/beans.xml
+++ b/custom-principal-ee/application/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,6 @@
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+          https://jakarta.ee/xml/ns/jakartaee
+          https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       bean-discovery-mode="all"/>

--- a/custom-principal-ee/application/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/custom-principal-ee/application/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,7 @@
+<jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.3">
+    <deployment>
+        <dependencies>
+            <module name="org.wildfly.security.examples.custom-principal-ee-components"/>
+        </dependencies>
+    </deployment>
+</jboss-deployment-structure>

--- a/custom-principal-ee/application/src/main/webapp/WEB-INF/web.xml
+++ b/custom-principal-ee/application/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="
+            https://jakarta.ee/xml/ns/jakartaee
+            https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+         version="6.0">
+
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>secured</web-resource-name>
+            <url-pattern>/secured</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>*</role-name>
+        </auth-constraint>
+    </security-constraint>
+
+    <security-role>
+        <role-name>*</role-name>
+    </security-role>
+
+</web-app>

--- a/custom-principal-ee/components/pom.xml
+++ b/custom-principal-ee/components/pom.xml
@@ -1,0 +1,30 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.security.examples</groupId>
+        <artifactId>custom-principal-ee</artifactId>
+        <version>2.0.0.Alpha1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>custom-principal-ee-components</artifactId>
+    <version>2.0.0.Alpha1-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-elytron-integration</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-auth-server</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+    </build>
+</project>

--- a/custom-principal-ee/components/src/main/java/org/wildfly/security/examples/CustomNameRewriter.java
+++ b/custom-principal-ee/components/src/main/java/org/wildfly/security/examples/CustomNameRewriter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.examples;
+
+import java.util.regex.Pattern;
+
+import org.wildfly.extension.elytron.capabilities.PrincipalTransformer;
+import org.wildfly.security.auth.principal.NamePrincipal;
+import org.wildfly.security.auth.util.RegexNameRewriter;
+
+public class CustomNameRewriter {
+
+    /**
+     * Acts like {@link RegexNameRewriter}, but operates on both {@link CustomPrincipal} and other types of
+     * {@link java.security.Principal Principal} with a name set.
+     *
+     * @return a {@link PrincipalTransformer}. It will return {@link CustomPrincipal} if the input was the same type,
+     * otherwise {@link NamePrincipal} if there was a valid name for the Principal, and if not then the original principal.
+     */
+    static PrincipalTransformer asPrincipalTransformer(String pattern, String replacement, boolean replaceAll) {
+        return PrincipalTransformer.from(
+            principal -> {
+                if (principal == null) {
+                    return null;
+                } else if (principal.getName() != null){
+                    RegexNameRewriter regexRewriter = new RegexNameRewriter(Pattern.compile(pattern), replacement, replaceAll);
+                    String rewritten = regexRewriter.rewriteName(principal.getName());
+
+                    if (principal instanceof CustomPrincipal) {
+                        CustomPrincipal cPrincipal = (CustomPrincipal) principal;
+                        return rewritten == null ? null : new CustomPrincipal(rewritten,
+                                cPrincipal.getLastLoginTime(), cPrincipal.getCurrentLoginTime());
+                    } else { // CustomPrincipal not being used
+                        return rewritten == null ? null : new NamePrincipal(rewritten);
+                    }
+                } else return principal;
+            }
+        );
+    }
+}

--- a/custom-principal-ee/components/src/main/java/org/wildfly/security/examples/CustomPrincipal.java
+++ b/custom-principal-ee/components/src/main/java/org/wildfly/security/examples/CustomPrincipal.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.examples;
+
+import java.io.Serializable;
+import java.security.Principal;
+import java.time.LocalDateTime;
+
+import org.wildfly.security.auth.principal.NamePrincipal;
+
+/**
+ * Custom implementation of a {@link Principal}, storing the timestamp when a user attempts to login,
+ * and of the last time they logged in.
+ *
+ * @author <a href="mailto:carodrig@redhat.com">Cameron Rodriguez</a>
+ */
+public class CustomPrincipal implements Principal, Serializable {
+
+    private static final long serialVersionUID = -7725026682598731089L;
+    private final LocalDateTime currentLoginTime;
+    private final LocalDateTime lastLoginTime;
+    private final Principal wrappedPrincipal;
+
+    public CustomPrincipal(Principal principal, LocalDateTime lastLoginTime) {
+        this.wrappedPrincipal = principal;
+        this.currentLoginTime = LocalDateTime.now();
+        this.lastLoginTime = lastLoginTime != null ? lastLoginTime : this.currentLoginTime;
+    }
+
+    // Used for rewriting names of existing principals
+    CustomPrincipal(String name, LocalDateTime lastLoginTime, LocalDateTime currentLoginTime) {
+        this.wrappedPrincipal = new NamePrincipal(name);
+        this.currentLoginTime = currentLoginTime;
+        this.lastLoginTime = lastLoginTime;
+    }
+
+    public LocalDateTime getCurrentLoginTime() {
+        return this.currentLoginTime;
+    }
+
+    public LocalDateTime getLastLoginTime() {
+        return this.lastLoginTime;
+    }
+    @Override
+    public String getName() {
+        return wrappedPrincipal.getName();
+    }
+
+    @Override
+    public String toString() {
+        return getName();
+    }
+
+    @Override
+    public boolean equals(final Object object) {
+        return object instanceof CustomPrincipal && this.equals((CustomPrincipal)object);
+    }
+
+    // Only compares names
+    public boolean equals(final CustomPrincipal principal) {
+        return principal.getName().equals(this.getName());
+    }
+}

--- a/custom-principal-ee/components/src/main/java/org/wildfly/security/examples/CustomTransformer.java
+++ b/custom-principal-ee/components/src/main/java/org/wildfly/security/examples/CustomTransformer.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.examples;
+
+import java.security.Principal;
+import java.time.LocalDateTime;
+
+import org.wildfly.extension.elytron.capabilities.PrincipalTransformer;
+
+/**
+ * A transformer to create a custom principal. A {@link PrincipalTransformer} is not necessary when not using
+ * the integrated JASPI (the functionality can be directly implemented in the {@code CustomAuthenticationMechanism}), but
+ * is used here for consistency with the other custom principal examples.
+ *
+ * @author <a href="mailto:carodrig@redhat.com">Cameron Rodriguez</a>
+ */
+public class CustomTransformer implements PrincipalTransformer {
+
+    private static final int LOGIN_DELTA_DAYS = 10;
+    private static final PrincipalTransformer delegate = CustomNameRewriter.asPrincipalTransformer(
+            "quickstartUser", "customQuickstartUser", false);
+
+    @Override
+    public Principal apply(Principal principal) {
+        return new CustomPrincipal(delegate.apply(principal), LocalDateTime.now().minusDays(LOGIN_DELTA_DAYS));
+    }
+
+}

--- a/custom-principal-ee/configure-elytron.cli
+++ b/custom-principal-ee/configure-elytron.cli
@@ -1,0 +1,20 @@
+# Load custom components as a global module
+module add --name=org.wildfly.security.examples.custom-principal-ee-components --resources=/PATH/TO/elytron-examples/custom-principal-ee/components/target/custom-principal-ee-components.jar --dependencies=org.wildfly.security.elytron,org.wildfly.extension.elytron
+reload
+
+# Start batching
+batch
+
+# Enable a default JACC policy for Elytron
+/subsystem=elytron/policy=jacc:add(jacc-policy={})
+
+# Create security domain
+/subsystem=elytron/security-domain=principalSecDomain:add(permission-mapper=default-permission-mapper)
+
+# Add the security domain mapping to Undertow and disable integrated JASPI
+/subsystem=undertow/application-security-domain=other:write-attribute(name=security-domain,value=principalSecDomain)
+/subsystem=undertow/application-security-domain=other:write-attribute(name=integrated-jaspi,value=false)
+
+# Run batch
+run-batch
+reload

--- a/custom-principal-ee/pom.xml
+++ b/custom-principal-ee/pom.xml
@@ -1,0 +1,64 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.wildfly.security.examples</groupId>
+    <artifactId>custom-principal-ee</artifactId>
+    <version>2.0.0.Alpha1-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+
+        <version.org.wildfly.core.wildfly-elytron-integration>20.0.0.Beta7</version.org.wildfly.core.wildfly-elytron-integration>
+        <version.org.wildfly.plugins.wildfly-maven-plugin>4.0.0.Final</version.org.wildfly.plugins.wildfly-maven-plugin>
+        <version.server.bom>27.0.1.Final</version.server.bom>
+    </properties>
+
+    <modules>
+        <module>components</module>
+        <module>application</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.wildfly.security.examples</groupId>
+                <artifactId>custom-principal-ee-components</artifactId>
+                <version>${project.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-ee-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.core</groupId>
+                <artifactId>wildfly-elytron-integration</artifactId>
+                <version>${version.org.wildfly.core.wildfly-elytron-integration}</version>
+                <scope>provided</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.wildfly.plugins</groupId>
+                    <artifactId>wildfly-maven-plugin</artifactId>
+                    <version>${version.org.wildfly.plugins.wildfly-maven-plugin}</version>
+                    <configuration>
+                        <skip>true</skip>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/custom-principal-ee/restore-configuration.cli
+++ b/custom-principal-ee/restore-configuration.cli
@@ -1,0 +1,20 @@
+# Start batching
+batch
+
+# Remove the security domain mapping to Undertow and restore integrated JASPI
+/subsystem=undertow/application-security-domain=other:write-attribute(name=integrated-jaspi,value=true)
+/subsystem=undertow/application-security-domain=other:write-attribute(name=security-domain, value=ApplicationDomain)
+
+# Remove security domain and custom principal transformer
+/subsystem=elytron/security-domain=principalSecDomain:remove()
+
+# Remove default JACC policy for Elytron
+/subsystem=elytron/policy=jacc:remove()
+
+# Run batch
+run-batch
+reload
+
+# Remove custom components module
+module remove --name=org.wildfly.security.examples.custom-principal-ee-components
+reload

--- a/custom-principal-ejb/README.md
+++ b/custom-principal-ejb/README.md
@@ -1,0 +1,194 @@
+# Using custom principals with EJBs
+
+This example demonstrates how to use custom principals with EJBs. The server uses a custom Elytron
+transformer to create the custom principal. When a client is authenticated, the principal is
+injected into the EJB using the `SessionContext` class, and it can be retrieved by the client.
+
+This demo is based on the [custom-principal-transformer](../custom-principal-transformer)
+and [ejb-security](../ejb-security) examples. For more information on how principal transformers
+work, see [this blog post](http://darranl.blogspot.com/2017/07/wildfly-elytron-principal-transformers.html).
+
+## Usage
+
+### Use of WILDFLY_HOME
+
+In the following instructions, replace `WILDFLY_HOME` with the actual path to your WildFly
+installation.
+
+## Back up the WildFly Standalone Server Configuration
+
+Before you begin, back up your server configuration file.
+
+1. If it is running, stop the WildFly server.
+2. Back up the `WILDFLY_HOME/standalone/configuration/standalone.xml` file.
+
+After you have completed testing this example, you can replace this file to restore the server to
+its original configuration.
+
+### Start the WildFly Server
+
+First, clone the `elytron-examples` repo locally:
+
+```shell
+    $ git clone https://github.com/wildfly-security-incubator/elytron-examples
+    $ cd elytron-examples
+```
+
+Then, start the server:
+
+```shell
+    $ WILDFLY_HOME/bin/standalone.sh
+```
+
+### Build the Demo App
+
+1. Make sure you start the WildFly server as described above.
+2. Open a new terminal and navigate to the root directory of this example.
+3. Type the following command to build the artifacts. JARs will be exported
+   to `custom-principal-ejb/application/target` and `custom-principal-ejb/components/target`.
+
+```shell
+    $ mvn clean install
+```
+
+### Configure Elytron
+
+#### Deploy custom principal and transformers
+
+Review the `configure-elytron.cli` file in the root of this example directory. This quickstart
+includes two Maven modules, and the CLI script performs a number of operations on the `components`
+module, which contains our custom principal:
+
+1. The `custom-principal-ejb-components` archive is added as a module to the server. This allows the
+   custom components to be used by the server.
+2. A filesystem realm is created, and an identity is created for the
+   user `customQuickstartUserFinal`.
+3. A custom pre-realm-principal-transformer (from the
+   class [CustomPreRealmTransformer](./components/src/main/java/org/wildfly/security/examples/CustomPreRealmTransformer.java))
+   is added. This transformer converts the internal NamePrincipal into our custom format, and is
+   required to use it.
+4. Custom post-realm and final principal transformers are added to rename the principal. Note that
+   these classes wrap
+   [CustomNameRewriter](./components/src/main/java/org/wildfly/security/examples/CustomNameRewriter.java);
+   even though the functionality is the same as the `regex-principal-transformer`, the use of a
+   custom principal means a default transformer can't be used.
+5. A security domain is created, referencing the filesystem realm and the pre-realm and post-realm
+   transformers.
+6. A SASL authentication factory is created, referencing both the security domain and the final
+   principal transformer.
+7. The EJB subsystem is updated to use the new security domain, and the Remoting subsystem for the
+   authentication factory.
+
+In the `configure-elytron.cli` script, replace `/PATH/TO` with the parent directory of
+the `elytron-examples`repo. Then, open a new terminal, navigate to the root directory of this
+example andrun the following command, replacing `WILDFLY_HOME` with the path to your server.
+
+```shell
+    $ WILDFLY_HOME/bin/jboss-cli.sh --connect --file=configure-elytron.cli
+```
+
+> NOTE: For Windows, use the `WILDFLY_HOME\bin\jboss-cli.bat` script.
+
+You should see the following result when you run the script:
+
+```shell
+    The batch executed successfully
+    process-state: reload-required
+```
+
+#### Deploy the EJBs
+
+Next, deploy the EJBs, built from the `custom-principal-ejb-application` module, to the server:
+
+1. Open a terminal and navigate to the root directory of this quickstart.
+2. Type the following command to deploy the EJB to the server.
+
+```shell
+    $ mvn wildfly:deploy
+```
+
+This deploys the `custom-principal-ejb/application/target/custom-principal-ejb.jar` to the running
+instance of the server. You should see a message in the server log indicating that the archive
+deployed successfully.
+
+### Run the Client
+
+Before you run the client, make sure you have successfully deployed both artifacts to the server in
+the previous step, and that your terminal is still in the root directory of this example.
+
+Run this command to execute the client:
+
+```shell
+    $ mvn exec:exec
+```
+
+### Investigate the Console Output
+
+When you run the `mvn exec:exec` command, you should see the following output.
+
+```
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+Successfully called secured bean as unauthenticated user
+EJBContext records principal as anonymous
+
+Custom principal usage test:
+[Via EJBContext] Last login is not applicable. Secrets access is disabled.
+
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+Successfully called secured bean as authenticated user
+EJBContext records principal as customQuickstartUserPre
+
+Custom principal usage test:
+[Via EJBContext] Last login was 10 days ago. Secrets access is enabled.
+
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+```
+
+The first block
+invokes [PrincipalProviderEJBUnsecured](./application/src/main/java/org/wildfly/security/examples/PrincipalProviderEJBUnsecured.java)
+and retrieves the principal using JNDI lookup. This EJB does not require authentication, so calls
+are made as an anonymous principal and no permissions can be derived.
+
+The second block
+accesses [PrincipalProviderEJBSecured](./application/src/main/java/org/wildfly/security/examples/PrincipalProviderEJBSecured.java),
+which requires authentication and logs in the user. The returned principal is the result of the
+pre-realm transformer, which converts the principal into
+the [CustomPrincipal](./components/src/main/java/org/wildfly/security/examples/CustomPrincipal.java)
+class. This class contains additional fields and methods for login times. This principal is then
+made available to `SessionContext` (an implementation of `EJBContext`), which is injected into the
+EJB.
+
+When the EJB is invoked, the custom principal `customQuickstartUserPre` can be used to perform
+class-specific operations. In this example, it retrieves the current and last login date, to
+determine if the client can still access secrets.
+
+### Undeploy the App and Restore the WildFly Standalone Server Configuration
+
+You can restore the original server configuration by undeploying the EJB, and running
+the `restore-configuration.cli` script provided in the root directory of this example. Perform the
+following steps to restore the original configuration:
+
+1. Start the WildFly server.
+2. Open a new terminal, navigate to the root directory of this example, and run the following
+   commands:
+
+```shell
+    $ mvn wildfly:undeploy
+    $ WILDFLY_HOME/bin/jboss-cli.sh --connect --file=restore-configuration.cli
+```
+
+> NOTE: For Windows, use the ```WILDFLY_HOME\bin\jboss-cli.bat``` script.
+
+You should see the following output when you run the script:
+
+```shell
+    The batch executed successfully
+    process-state: reload-required
+    The batch executed successfully
+    process-state: reload-required
+```

--- a/custom-principal-ejb/application/pom.xml
+++ b/custom-principal-ejb/application/pom.xml
@@ -1,0 +1,51 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.security.examples</groupId>
+        <artifactId>custom-principal-ejb</artifactId>
+        <version>2.0.0.Alpha1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>custom-principal-ejb-application</artifactId>
+    <version>2.0.0.Alpha1-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wildfly.security.examples</groupId>
+            <artifactId>custom-principal-ejb-components</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-ejb-client-bom</artifactId>
+            <type>pom</type>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.parent.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-ejb-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/custom-principal-ejb/application/src/main/java/org/wildfly/security/examples/PrincipalProviderEJBInterface.java
+++ b/custom-principal-ejb/application/src/main/java/org/wildfly/security/examples/PrincipalProviderEJBInterface.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.examples;
+
+import java.security.Principal;
+
+/**
+ * The interface used to access the SecuredEJB.
+ *
+ * @author <a href="mailto:sguilhen@redhat.com">Stefan Guilhen</a>
+ * @author <a href="mailto:carodrig@redhat.com">Cameron Rodriguez</a>
+ */
+public interface PrincipalProviderEJBInterface {
+
+    /**
+     * @return the caller principal from {@link jakarta.ejb.EJBContext}.
+     */
+    Principal getEJBCallerPrincipal();
+
+    /**
+     * @return the number of days since the last login, or -1 if unavailable.
+     */
+    long daysSinceLogin();
+
+    /**
+     * @return whether the authenticated user is permitted to access secrets. If it has been longer than 30 days since
+     * the last login, secrets access is disabled.
+     */
+    boolean secretsAccess();
+}

--- a/custom-principal-ejb/application/src/main/java/org/wildfly/security/examples/PrincipalProviderEJBSecured.java
+++ b/custom-principal-ejb/application/src/main/java/org/wildfly/security/examples/PrincipalProviderEJBSecured.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.examples;
+
+import static java.time.temporal.ChronoUnit.DAYS;
+
+import java.security.Principal;
+
+import jakarta.annotation.Resource;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ejb.Remote;
+import jakarta.ejb.SessionContext;
+import jakarta.ejb.Stateless;
+
+import org.jboss.ejb3.annotation.SecurityDomain;
+
+/**
+ * Simple secured EJB using EJB security annotations.
+ *
+ * @author Sherif Makary
+ * @author <a href="mailto:carodrig@redhat.com">Cameron Rodriguez</a>
+ */
+@Stateless
+@Remote(PrincipalProviderEJBInterface.class)
+@RolesAllowed({ "Login" })
+@SecurityDomain("principalEJB")
+public class PrincipalProviderEJBSecured implements PrincipalProviderEJBInterface {
+
+    // Inject the Session Context
+    @Resource
+    private SessionContext ejbCtx;
+
+    /**
+     * @return the authenticated principal
+     */
+    @Override
+    public Principal getEJBCallerPrincipal() {
+        // Session context injected using the resource annotation
+        return ejbCtx.getCallerPrincipal();
+    }
+
+    @Override
+    public long daysSinceLogin() {
+        CustomPrincipal principal = (CustomPrincipal) getEJBCallerPrincipal();
+        if (principal.getLastLoginTime().equals(principal.getCurrentLoginTime())) {
+            return -1;
+        } else {
+            return DAYS.between(principal.getLastLoginTime(), principal.getCurrentLoginTime());
+        }
+    }
+
+    @Override
+    public boolean secretsAccess() {
+        return daysSinceLogin() <= 30;
+    }
+}

--- a/custom-principal-ejb/application/src/main/java/org/wildfly/security/examples/PrincipalProviderEJBUnsecured.java
+++ b/custom-principal-ejb/application/src/main/java/org/wildfly/security/examples/PrincipalProviderEJBUnsecured.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.examples;
+
+import java.security.Principal;
+
+import jakarta.annotation.Resource;
+import jakarta.ejb.Remote;
+import jakarta.ejb.SessionContext;
+import jakarta.ejb.Stateless;
+
+/**
+ * Simple unsecured EJB.
+ *
+ * @author Sherif Makary
+ * @author <a href="mailto:carodrig@redhat.com">Cameron Rodriguez</a>
+ */
+@Stateless
+@Remote(PrincipalProviderEJBInterface.class)
+public class PrincipalProviderEJBUnsecured implements PrincipalProviderEJBInterface {
+
+    // Inject the Session Context
+    @Resource
+    private SessionContext ejbCtx;
+
+    /**
+     * @return the unauthenticated principal
+     */
+    @Override
+    public Principal getEJBCallerPrincipal() {
+        // Session context injected using the resource annotation
+        return ejbCtx.getCallerPrincipal();
+    }
+
+    @Override
+    public long daysSinceLogin() {
+        return -1;
+    }
+
+    // Unauthenticated users may not access secrets.
+    @Override
+    public boolean secretsAccess() {
+        return false;
+    }
+}

--- a/custom-principal-ejb/application/src/main/java/org/wildfly/security/examples/RemoteClient.java
+++ b/custom-principal-ejb/application/src/main/java/org/wildfly/security/examples/RemoteClient.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.examples;
+
+import java.util.Hashtable;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+/**
+ * The remote client responsible for making invoking the intermediate bean to demonstrate invocation of custom
+ * principals in EJB to remote EJB calls.
+ *
+ * @author <a href="mailto:sguilhen@redhat.com">Stefan Guilhen</a>
+ * @author <a href="mailto:carodrig@redhat.com">Cameron Rodriguez</a>
+ */
+public class RemoteClient {
+
+    public static void main(String[] args) throws Exception {
+        System.out.println("Connecting as unauthenticated user, then as authenticated user");
+        connect(false);
+        connect(true);
+    }
+
+    private static void connect(boolean auth) throws NamingException {
+        final Hashtable<String, String> jndiProperties = new Hashtable<>();
+        jndiProperties.put(Context.INITIAL_CONTEXT_FACTORY, "org.wildfly.naming.client.WildFlyInitialContextFactory");
+        jndiProperties.put(Context.PROVIDER_URL, "remote+http://localhost:8080");
+        final Context context = new InitialContext(jndiProperties);
+
+        final String moduleName = "custom-principal-ejb";
+        final String beanName = auth ? PrincipalProviderEJBSecured.class.getSimpleName() : PrincipalProviderEJBUnsecured.class.getSimpleName();
+        final String interfaceName = PrincipalProviderEJBInterface.class.getName();
+        PrincipalProviderEJBInterface beanReference = (PrincipalProviderEJBInterface) context.lookup("ejb:/" + moduleName + "/"
+                + beanName + "!" + interfaceName);
+
+        System.out.println("\n* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *\n");
+        System.out.println("Successfully called secured bean as " + (auth ? "authenticated user" : "unauthenticated user"));
+        System.out.println("EJBContext records principal as " + beanReference.getEJBCallerPrincipal());
+
+        long days = beanReference.daysSinceLogin();
+        System.out.println("\nCustom principal usage test:");
+        System.out.printf("[Via EJBContext] Last login %s. Secrets access is %s.\n", (days != -1 ? String.format("was %d days ago", days) : "is not applicable" ),
+                                                                        (beanReference.secretsAccess() ? "enabled" : "disabled"));
+        System.out.println("\n* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *\n");
+    }
+}

--- a/custom-principal-ejb/application/src/main/resources/META-INF/jboss-deployment-structure.xml
+++ b/custom-principal-ejb/application/src/main/resources/META-INF/jboss-deployment-structure.xml
@@ -1,0 +1,7 @@
+<jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.3">
+    <deployment>
+        <dependencies>
+            <module name="org.wildfly.security.examples.custom-principal-ejb-components"/>
+        </dependencies>
+    </deployment>
+</jboss-deployment-structure>

--- a/custom-principal-ejb/application/src/main/resources/wildfly-config.xml
+++ b/custom-principal-ejb/application/src/main/resources/wildfly-config.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2022, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<configuration>
+    <authentication-client xmlns="urn:elytron:client:1.7">
+        <authentication-rules>
+            <rule use-configuration="authenticated"/>
+        </authentication-rules>
+        <authentication-configurations>
+            <configuration name="authenticated">
+                <set-user-name name="quickstartUser"/>
+                <credentials>
+                    <clear-password password="password123!"/>
+                </credentials>
+                <sasl-mechanism-selector selector="SCRAM-SHA-256"/>
+                <providers>
+                    <use-service-loader/>
+                </providers>
+            </configuration>
+        </authentication-configurations>
+    </authentication-client>
+</configuration>

--- a/custom-principal-ejb/components/pom.xml
+++ b/custom-principal-ejb/components/pom.xml
@@ -1,0 +1,31 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.security.examples</groupId>
+        <artifactId>custom-principal-ejb</artifactId>
+        <version>2.0.0.Alpha1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>custom-principal-ejb-components</artifactId>
+    <version>2.0.0.Alpha1-SNAPSHOT</version>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-elytron-integration</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-auth-server</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+    </build>
+</project>

--- a/custom-principal-ejb/components/src/main/java/org/wildfly/security/examples/CustomFinalTransformer.java
+++ b/custom-principal-ejb/components/src/main/java/org/wildfly/security/examples/CustomFinalTransformer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.examples;
+
+import java.security.Principal;
+
+import org.wildfly.extension.elytron.capabilities.PrincipalTransformer;
+
+/**
+ * A {@link PrincipalTransformer} to change the name of the {@link CustomPrincipal} as a final step.
+ *
+ * @author <a href="mailto:carodrig@redhat.com">Cameron Rodriguez</a>
+ */
+public class CustomFinalTransformer implements PrincipalTransformer {
+
+    private static final PrincipalTransformer delegate = CustomNameRewriter.asPrincipalTransformer(
+            "QuickstartUserPost", "QuickstartUserFinal", false);
+
+    @Override
+    public Principal apply(Principal principal) {
+        return delegate.apply(principal);
+    }
+}

--- a/custom-principal-ejb/components/src/main/java/org/wildfly/security/examples/CustomNameRewriter.java
+++ b/custom-principal-ejb/components/src/main/java/org/wildfly/security/examples/CustomNameRewriter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.examples;
+
+import java.util.regex.Pattern;
+
+import org.wildfly.extension.elytron.capabilities.PrincipalTransformer;
+import org.wildfly.security.auth.principal.NamePrincipal;
+import org.wildfly.security.auth.util.RegexNameRewriter;
+
+public class CustomNameRewriter {
+
+    /**
+     * Acts like {@link RegexNameRewriter}, but operates on both {@link CustomPrincipal} and other types of
+     * {@link java.security.Principal Principal} with a name set.
+     *
+     * @return a {@link PrincipalTransformer}. It will return {@link CustomPrincipal} if the input was the same type,
+     * otherwise {@link NamePrincipal} if there was a valid name for the Principal, and if not then the original principal.
+     */
+    static PrincipalTransformer asPrincipalTransformer(String pattern, String replacement, boolean replaceAll) {
+        return PrincipalTransformer.from(
+            principal -> {
+                if (principal == null) {
+                    return null;
+                } else if (principal.getName() != null){
+                    RegexNameRewriter regexRewriter = new RegexNameRewriter(Pattern.compile(pattern), replacement, replaceAll);
+                    String rewritten = regexRewriter.rewriteName(principal.getName());
+
+                    if (principal instanceof CustomPrincipal) {
+                        CustomPrincipal cPrincipal = (CustomPrincipal) principal;
+                        return rewritten == null ? null : new CustomPrincipal(rewritten,
+                                cPrincipal.getLastLoginTime(), cPrincipal.getCurrentLoginTime());
+                    } else { // CustomPrincipal not being used
+                        return rewritten == null ? null : new NamePrincipal(rewritten);
+                    }
+                } else return principal;
+            }
+        );
+    }
+}

--- a/custom-principal-ejb/components/src/main/java/org/wildfly/security/examples/CustomPostRealmTransformer.java
+++ b/custom-principal-ejb/components/src/main/java/org/wildfly/security/examples/CustomPostRealmTransformer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.examples;
+
+import java.security.Principal;
+
+import org.wildfly.extension.elytron.capabilities.PrincipalTransformer;
+
+/**
+ * A {@link PrincipalTransformer} to change the name of the {@link CustomPrincipal} after the realm is assigned.
+ *
+ * @author <a href="mailto:carodrig@redhat.com">Cameron Rodriguez</a>
+ */
+public class CustomPostRealmTransformer implements PrincipalTransformer {
+
+    private static final PrincipalTransformer delegate = CustomNameRewriter.asPrincipalTransformer(
+            "QuickstartUserPre", "QuickstartUserPost", false);
+
+    @Override
+    public Principal apply(Principal principal) {
+        return delegate.apply(principal);
+    }
+}

--- a/custom-principal-ejb/components/src/main/java/org/wildfly/security/examples/CustomPreRealmTransformer.java
+++ b/custom-principal-ejb/components/src/main/java/org/wildfly/security/examples/CustomPreRealmTransformer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.examples;
+
+import java.security.Principal;
+import java.time.LocalDateTime;
+
+import org.wildfly.extension.elytron.capabilities.PrincipalTransformer;
+
+/**
+ * A {@link PrincipalTransformer} to create a custom principal. An offset {@value LOGIN_DELTA_DAYS LOGIN_DELTA_DAYS} is used to simulate the time since the last
+ * user was logged in.
+ *
+ * @author <a href="mailto:carodrig@redhat.com">Cameron Rodriguez</a>
+ */
+public class CustomPreRealmTransformer implements PrincipalTransformer {
+
+    private static final int LOGIN_DELTA_DAYS = 10;
+    private static final PrincipalTransformer delegate = CustomNameRewriter.asPrincipalTransformer(
+            "quickstartUser", "customQuickstartUserPre", false);
+
+    @Override
+    public Principal apply(Principal principal) {
+        return new CustomPrincipal(delegate.apply(principal), LocalDateTime.now().minusDays(LOGIN_DELTA_DAYS));
+    }
+
+}

--- a/custom-principal-ejb/components/src/main/java/org/wildfly/security/examples/CustomPrincipal.java
+++ b/custom-principal-ejb/components/src/main/java/org/wildfly/security/examples/CustomPrincipal.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.examples;
+
+import java.io.Serializable;
+import java.security.Principal;
+import java.time.LocalDateTime;
+
+import org.wildfly.security.auth.principal.NamePrincipal;
+
+/**
+ * Custom implementation of a {@link Principal}, storing the timestamp when a user attempts to login,
+ * and of the last time they logged in.
+ *
+ * @author <a href="mailto:carodrig@redhat.com">Cameron Rodriguez</a>
+ */
+public class CustomPrincipal implements Principal, Serializable {
+
+    private static final long serialVersionUID = -7725026682598731089L;
+    private final LocalDateTime currentLoginTime;
+    private final LocalDateTime lastLoginTime;
+    private final Principal wrappedPrincipal;
+
+    public CustomPrincipal(Principal principal, LocalDateTime lastLoginTime) {
+        this.wrappedPrincipal = principal;
+        this.currentLoginTime = LocalDateTime.now();
+        this.lastLoginTime = lastLoginTime != null ? lastLoginTime : this.currentLoginTime;
+    }
+
+    // Used for rewriting names of existing principals
+    CustomPrincipal(String name, LocalDateTime lastLoginTime, LocalDateTime currentLoginTime) {
+        this.wrappedPrincipal = new NamePrincipal(name);
+        this.currentLoginTime = currentLoginTime;
+        this.lastLoginTime = lastLoginTime;
+    }
+
+    public LocalDateTime getCurrentLoginTime() {
+        return this.currentLoginTime;
+    }
+
+    public LocalDateTime getLastLoginTime() {
+        return this.lastLoginTime;
+    }
+    @Override
+    public String getName() {
+        return wrappedPrincipal.getName();
+    }
+
+    @Override
+    public String toString() {
+        return getName();
+    }
+
+    @Override
+    public boolean equals(final Object object) {
+        return object instanceof CustomPrincipal && this.equals((CustomPrincipal)object);
+    }
+
+    // Only compares names
+    public boolean equals(final CustomPrincipal principal) {
+        return principal.getName().equals(this.getName());
+    }
+}

--- a/custom-principal-ejb/configure-elytron.cli
+++ b/custom-principal-ejb/configure-elytron.cli
@@ -1,0 +1,30 @@
+# Load custom components module
+module add --name=org.wildfly.security.examples.custom-principal-ejb-components --resources=/PATH/TO/elytron-examples/custom-principal-ejb/components/target/custom-principal-ejb-components.jar --dependencies=org.wildfly.security.elytron,org.wildfly.extension.elytron
+
+# Start batching
+batch
+
+# Create security realm and identity
+/subsystem=elytron/filesystem-realm=principalRealm:add(path=principal-realm,relative-to=jboss.server.config.dir)
+/subsystem=elytron/filesystem-realm=principalRealm:add-identity(identity=customQuickstartUserFinal)
+/subsystem=elytron/filesystem-realm=principalRealm:set-password(identity=customQuickstartUserFinal,clear={password=password123!})
+/subsystem=elytron/filesystem-realm=principalRealm:add-identity-attribute(identity=customQuickstartUserFinal,name=Roles,value=[Login])
+
+# Add custom pre-realm principal transformer
+/subsystem=elytron/custom-principal-transformer=customPreRealmTransformer:add(module=org.wildfly.security.examples.custom-principal-ejb-components,class-name=org.wildfly.security.examples.CustomPreRealmTransformer)
+
+# Create custom post-realm and final regex rewriters (a type of transformer)
+/subsystem=elytron/custom-principal-transformer=customPostRealmRewriter:add(module=org.wildfly.security.examples.custom-principal-ejb-components,class-name=org.wildfly.security.examples.CustomPostRealmTransformer)
+/subsystem=elytron/custom-principal-transformer=customFinalRewriter:add(module=org.wildfly.security.examples.custom-principal-ejb-components,class-name=org.wildfly.security.examples.CustomFinalTransformer)
+
+# Create security domain and SASL authentication factory, add realms and transformers
+/subsystem=elytron/security-domain=principalSecDomain:add(realms=[{realm=principalRealm}],default-realm=principalRealm,pre-realm-principal-transformer=customPreRealmTransformer,post-realm-principal-transformer=customPostRealmRewriter,permission-mapper=default-permission-mapper)
+/subsystem=elytron/sasl-authentication-factory=principalAuthFactory:add(sasl-server-factory=configured,security-domain=principalSecDomain,mechanism-configurations=[{mechanism-name=SCRAM-SHA-256,final-principal-transformer=customFinalRewriter}])
+
+# Add security domain to EJB subsystem, update Remoting HTTP connector to use SASL authentication factory
+/subsystem=ejb3/application-security-domain=principalEJB:add(security-domain=principalSecDomain)
+/subsystem=remoting/http-connector=http-remoting-connector:write-attribute(name=sasl-authentication-factory,value=principalAuthFactory)
+
+# Run batch
+run-batch
+reload

--- a/custom-principal-ejb/pom.xml
+++ b/custom-principal-ejb/pom.xml
@@ -1,0 +1,97 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.wildfly.security.examples</groupId>
+    <artifactId>custom-principal-ejb</artifactId>
+    <version>2.0.0.Alpha1-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+
+        <version.org.apache.maven.plugins.maven-ejb-plugin>3.2.1</version.org.apache.maven.plugins.maven-ejb-plugin>
+        <version.org.codehaus.mojo.exec-maven-plugin>3.1.0</version.org.codehaus.mojo.exec-maven-plugin>
+        <version.org.wildfly.core.wildfly-elytron-integration>20.0.0.Beta7</version.org.wildfly.core.wildfly-elytron-integration>
+        <version.org.wildfly.plugins.wildfly-maven-plugin>4.0.0.Final</version.org.wildfly.plugins.wildfly-maven-plugin>
+        <version.server.bom>27.0.1.Final</version.server.bom>
+    </properties>
+
+    <modules>
+        <module>components</module>
+        <module>application</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.wildfly.security.examples</groupId>
+                <artifactId>custom-principal-ejb-components</artifactId>
+                <version>${project.version}</version>
+                <scope>compile</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-ee-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.core</groupId>
+                <artifactId>wildfly-elytron-integration</artifactId>
+                <version>${version.org.wildfly.core.wildfly-elytron-integration}</version>
+                <scope>provided</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-ejb-plugin</artifactId>
+                    <version>${version.org.apache.maven.plugins.maven-ejb-plugin}</version>
+                    <configuration>
+                        <ejbVersion>${version.org.apache.maven.plugins.maven-ejb-plugin}</ejbVersion>
+                        <generateClient>true</generateClient>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <version>${version.org.codehaus.mojo.exec-maven-plugin}</version>
+                    <configuration>
+                        <skip>true</skip>
+                        <executable>java</executable>
+                        <workingDirectory>${project.build.directory}/exec-working-directory</workingDirectory>
+                        <arguments>
+                            <argument>-classpath</argument>
+                            <classpath/>
+                            <argument>org.wildfly.security.examples.RemoteClient</argument>
+                        </arguments>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>exec</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.wildfly.plugins</groupId>
+                    <artifactId>wildfly-maven-plugin</artifactId>
+                    <version>${version.org.wildfly.plugins.wildfly-maven-plugin}</version>
+                    <configuration>
+                        <skip>true</skip>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/custom-principal-ejb/restore-configuration.cli
+++ b/custom-principal-ejb/restore-configuration.cli
@@ -1,0 +1,29 @@
+# Start batching
+batch
+
+# Remove security domain to EJB subsystem, restore Remoting HTTP connector
+/subsystem=remoting/http-connector=http-remoting-connector:write-attribute(name=sasl-authentication-factory,value=application-sasl-authentication)
+/subsystem=ejb3/application-security-domain=principalEJB:remove()
+
+# Remove the SASL authentication factory and security domain
+/subsystem=elytron/sasl-authentication-factory=principalAuthFactory:remove()
+/subsystem=elytron/security-domain=principalSecDomain:remove()
+
+# Remove pre-, post-realm, and final transformers
+/subsystem=elytron/custom-principal-transformer=customFinalRewriter:remove()
+/subsystem=elytron/custom-principal-transformer=customPostRealmRewriter:remove()
+/subsystem=elytron/custom-principal-transformer=customPreRealmTransformer:remove()
+
+# Remove security identity
+/subsystem=elytron/filesystem-realm=principalRealm:remove-identity(identity=customQuickstartUserFinal)
+
+# Run batch
+run-batch
+reload
+
+# Remove security realm and custom components module
+batch
+/subsystem=elytron/filesystem-realm=principalRealm:remove()
+module remove --name=org.wildfly.security.examples.custom-principal-ejb-components
+run-batch
+reload

--- a/custom-principal-elytron/README.md
+++ b/custom-principal-elytron/README.md
@@ -1,0 +1,204 @@
+# Using custom principals with Elytron
+
+This example demonstrates how to use custom principals in Elytron. The
+examples [custom-principal-ee](../custom-principal-ee)
+and [custom-principal-ejb](../custom-principal-ejb) demonstrate standard use cases, where the
+principal can be retrieved from `SecurityContext` or `SessionContext` respectively. However, it is
+also possible to get a custom principal from `SecurityContext` without a full Jakarta Security
+implementation, which is explored in this example.
+
+The server uses a custom Elytron transformer to create the custom principal. When a client is
+authenticated, the principal is injected into the Servlet using the Jakarta `SecurityContext` class
+and the Elytron `SecurityDomain` class. The client can then retrieve the principal using either of
+these classes.
+
+This demo is based on the [custom-principal-transformer](../custom-principal-transformer)
+and [simple-webapp](../simple-webapp) examples. For more information on how principal transformers
+work, see [this blog post](http://darranl.blogspot.com/2017/07/wildfly-elytron-principal-transformers.html).
+
+## Usage
+
+### Use of WILDFLY_HOME
+
+In the following instructions, replace `WILDFLY_HOME` with the actual path to your WildFly
+installation.
+
+## Back up the WildFly Standalone Server Configuration
+
+Before you begin, back up your server configuration file.
+
+1. If it is running, stop the WildFly server.
+2. Back up the `WILDFLY_HOME/standalone/configuration/standalone.xml` file.
+
+After you have completed testing this example, you can replace this file to restore the server to
+its original configuration.
+
+### Start the WildFly Server
+
+First, clone the `elytron-examples` repo locally:
+
+```shell
+    $ git clone https://github.com/wildfly-security-incubator/elytron-examples
+    $ cd elytron-examples
+```
+
+Then, start the server:
+
+```shell
+    $ WILDFLY_HOME/bin/standalone.sh
+```
+
+### Build the Demo App
+
+1. Make sure you start the WildFly server as described above.
+2. Open a new terminal and navigate to the root directory of this example.
+3. Type the following command to build the artifacts. JARs will be exported
+   to `custom-principal-elytron/application/target`
+   and `custom-principal-elytron/components/target`.
+
+```shell
+    $ mvn clean install
+```
+
+### Configure Elytron
+
+#### Deploy custom principal and transformers
+
+Review the `configure-elytron.cli` file in the root of this example directory. This quickstart
+includes two Maven modules, and the CLI script performs a number of operations on the `components`
+module, which contains our custom principal:
+
+#### Deploy custom principal and transformers
+
+Review the `configure-elytron.cli` file in the root of this example directory. This quickstart
+includes two Maven modules, and the CLI script performs a number of operations on the `components`
+module, which contains our custom principal:
+
+1. The `custom-principal-elytron-components` archive is added as a module to the server. This allows
+   the custom components to be used by the server.
+2. A default JACC (Jakarta Authorization) policy is created, allowing deployments to use
+   the `SecurityContext` interface from the Jakarta Security API.
+3. A filesystem realm is created, and an identity is created for the
+   user `customQuickstartUserPost`.
+4. A custom pre-realm-principal-transformer (from the
+   class [CustomPreRealmTransformer](./components/src/main/java/org/wildfly/security/examples/CustomPreRealmTransformer.java))
+   is added. This transformer converts the internal NamePrincipal into our custom format, and is
+   required to use it.
+5. A custom post-realm transformer is added to rename the principal. Note that this classes
+   wraps [CustomNameRewriter](./components/src/main/java/org/wildfly/security/examples/CustomNameRewriter.java);
+   even though the functionality is the same as the `regex-principal-transformer`, the use of a
+   custom principal means a default transformer can't be used.
+6. A security domain is created, referencing the filesystem realm and the pre-realm and post-realm
+   transformers.
+7. The `application-security-domain` mapping in the Undertow subsystem is updated to reference this
+   security domain.
+
+In the `configure-elytron.cli` script, replace `/PATH/TO` with the parent directory of
+the `elytron-examples` repo. Then, open a new terminal, navigate to the root directory of this
+example andrun the following command, replacing `WILDFLY_HOME` with the path to your server.
+
+```shell
+    $ WILDFLY_HOME/bin/jboss-cli.sh --connect --file=configure-elytron.cli
+```
+
+> NOTE: For Windows, use the `WILDFLY_HOME\bin\jboss-cli.bat` script.
+
+You should see the following result when you run the script:
+
+```shell
+    The batch executed successfully
+    process-state: reload-required
+```
+
+#### Deploy the Web App
+
+Next, deploy the web app, built from the `custom-principal-elytron-application` module, to the
+server:
+
+1. Open a terminal and navigate to the root directory of this quickstart.
+2. Type the following command to deploy the web app to the server.
+
+```shell
+    $ mvn wildfly:deploy
+```
+
+This deploys the `custom-principal-elytron/application/target/custom-principal-elytron.war` to the
+running instance of the server. You should see a message in the server log indicating that the
+archive deployed successfully.
+
+### Log into the Web App
+
+You can go to `http://localhost:8080/custom-principal-elytron` to access the web application now.
+Selecting the `Access Secured Servlet` link will prompt you for a username and password to log in.
+If you correctly login with the credentials created in the setup (username: `quickstartUser`,
+password: `password123!`), you will be greeted by a page that shows you the principal you're logged
+in with, as well as how the principal was handled internally. The raw HTML is shown below:
+
+```html
+<!DOCTYPE html>
+<html>
+   <head><title>SecuredServlet - doGet()</title></head>
+   <body>
+      <h1>Custom Principal - Elytron Demo</h1>
+      <p>For reference, transform sequence is quickstartUser -> <em>customQuickstartUserPre</em> -> customQuickstartUserPost.</p>
+      <p>Injection check - these values should match:</p>
+      <ul>
+          <li>Identity as available from Jakarta Security (<code>SecurityContext</code>): <strong>customQuickstartUserPre</strong></li>
+          <li>Identity as available from injection (<code>SecurityIdentity</code>): <strong>customQuickstartUserPre</strong></li>
+          <li>Identity as provided in HTTPServletRequest: <strong>customQuickstartUserPre</strong></li>
+      </ul>
+      <p>Custom Principal check - these values should match:</p>
+      <ul>
+          <li>Caller principal<code>(SecurityContext.getCallerPrincipal)</code>: Class -> <strong>org.wildfly.security.examples.CustomPrincipal</strong>, Name -> <strong>customQuickstartUserPre</strong></li>
+          <li>Custom principal<code>(SecurityContext.getPrincipalsByType)</code>: Class -> <strong>org.wildfly.security.examples.CustomPrincipal</strong>, Name -> <strong>customQuickstartUserPre</strong></li>
+          <li>Injection<code>(SecurityIdentity.getPrincipal)</code>: Class -> <strong>org.wildfly.security.examples.CustomPrincipal</strong>, Name -> <strong>customQuickstartUserPre</strong></li>
+      </ul>
+      <p>Custom Principal usage - this check will return a result of <em>enabled</em> if the
+          CustomPrincipal was injected properly:</p>
+      <ul>
+          <li>SecurityContext reports last login <strong>was 10 days ago</strong>. Secrets access is <strong>enabled</strong>.</li>
+          <li>SecurityIdentity reports last login <strong>was 10 days ago</strong>. Secrets access is<strong>enabled</strong>.</li>
+   </body>
+</html>
+```
+
+### Understanding the Results
+
+When the client logs into the page, Elytron's authentication checks to see if the principal is
+present in the security realm. During authentication, the pre-realm transformer first converts the
+principal into
+the [CustomPrincipal](./components/src/main/java/org/wildfly/security/examples/CustomPrincipal.java)
+class. This class contains additional fields and methods for login times. The transformer also
+renames the principal to customQuickstartUserPre.
+
+When a principal is requested from
+the [SecuredServlet](./application/src/main/java/org/wildfly/security/examples/SecuredServlet.java),
+the custom principal can be returned. In this example, `customQuickstartUserPre` is used to retrieve
+the current and last login date. The servlet then uses this info to report if the user has access to
+secrets.
+
+### Undeploy the App and Restore the WildFly Standalone Server Configuration
+
+You can restore the original server configuration by undeploying the EJB, and running
+the `restore-configuration.cli` script provided in the root directory of this example. Perform the
+following steps to restore the original configuration:
+
+1. Start the WildFly server.
+2. Open a new terminal, navigate to the root directory of this example, and run the following
+   commands:
+
+```shell
+    $ mvn wildfly:undeploy
+    $ WILDFLY_HOME/bin/jboss-cli.sh --connect --file=restore-configuration.cli
+```
+
+> NOTE: For Windows, use the ```WILDFLY_HOME\bin\jboss-cli.bat``` script.
+
+You should see the following output when you run the script:
+
+```shell
+    The batch executed successfully
+    process-state: reload-required
+    The batch executed successfully
+    process-state: reload-required
+```

--- a/custom-principal-elytron/application/pom.xml
+++ b/custom-principal-elytron/application/pom.xml
@@ -1,0 +1,66 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.security.examples</groupId>
+        <artifactId>custom-principal-elytron</artifactId>
+        <version>2.0.0.Alpha1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>custom-principal-elytron-application</artifactId>
+    <version>2.0.0.Alpha1-SNAPSHOT</version>
+    <packaging>war</packaging>
+
+    <properties>
+        <version.io.undertow>2.3.5.Final</version.io.undertow>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wildfly.security.examples</groupId>
+            <artifactId>custom-principal-elytron-components</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-auth-server</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.undertow</groupId>
+            <artifactId>undertow-servlet</artifactId>
+            <version>${version.io.undertow}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.security.enterprise</groupId>
+            <artifactId>jakarta.security.enterprise-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.parent.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/custom-principal-elytron/application/src/main/java/org/wildfly/security/examples/SecuredServlet.java
+++ b/custom-principal-elytron/application/src/main/java/org/wildfly/security/examples/SecuredServlet.java
@@ -1,0 +1,129 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.examples;
+
+import static java.time.temporal.ChronoUnit.DAYS;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Set;
+
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.SecurityContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.HttpMethodConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.wildfly.security.auth.server.SecurityIdentity;
+
+/**
+ * A simple secured HTTP servlet.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ * @author <a href="mailto:carodrig@redhat.com">Cameron Rodriguez</a>
+ */
+@WebServlet("/secured")
+@ServletSecurity(httpMethodConstraints = { @HttpMethodConstraint(value = "GET", rolesAllowed = { "Login" }) })
+public class SecuredServlet extends HttpServlet {
+
+    private static final long serialVersionUID = -7255453900077536656L;
+    @Inject
+    SecurityContext securityContext;
+    @Inject
+    SecurityIdentity securityIdentity;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        try (PrintWriter pw = resp.getWriter()) {
+            pw.print(securedPage(req));
+        }
+    }
+
+    private String securedPage(HttpServletRequest req) {
+        String newline = System.getProperty("line.separator");
+        CustomPrincipal customPrincipalFromType = retrieveCustomPrincipalByType();
+
+        return String.join(newline,
+                "<!DOCTYPE html>",
+                "<html>",
+                "    <head><title>SecuredServlet - doGet()</title></head>",
+                "    <body>",
+                "        <h1>Custom Principal - Elytron Demo</h1>",
+                "        <p>For reference, transform sequence is quickstartUser -> <em>customQuickstartUserPre</em> -> customQuickstartUserPost.</p>",
+                "        <p>Injection check - these values should match:</p>",
+                "        <ul>",
+  String.format("            <li>Identity as available from Jakarta Security (<code>SecurityContext</code>): <strong>%s</strong></li>", securityContext.getCallerPrincipal().getName()),
+  String.format("            <li>Identity as available from injection (<code>SecurityIdentity</code>): <strong>%s</strong></li>", securityIdentity.getPrincipal().getName()),
+  String.format("            <li>Identity as provided in HTTPServletRequest: <strong>%s</strong>", req.getUserPrincipal()),
+                "        </ul>",
+                "        <p>Custom Principal check - these values should match:</p>",
+                "        <ul>",
+  String.format("            <li>Caller principal<code>(SecurityContext.getCallerPrincipal)</code>: Class -> <strong>%s</strong>, Name -> <strong>%s</strong></li>",
+                        securityContext.getCallerPrincipal().getClass().getCanonicalName(),
+                        securityContext.getCallerPrincipal().getName()),
+                customPrincipalFromType != null
+                        ? String.format("            <li>Custom principal<code>(SecurityContext.getPrincipalsByType)</code>: Class -> <strong>%s</strong>, Name -> <strong>%s</strong></li>",
+                                customPrincipalFromType.getClass().getCanonicalName(),
+                                customPrincipalFromType.getName())
+                        : String.format("            <li>Custom principal<code>(SecurityContext.getPrincipalsByType)</code>: Class -> <strong>%s</strong>, Name -> <strong>%s</strong></li>",
+                                "not found",
+                                "null"),
+  String.format("            <li>Injection<code>(SecurityIdentity.getPrincipal)</code>: Class -> <strong>%s</strong>, Name -> <strong>%s</strong></li>",
+                        securityIdentity.getPrincipal().getClass().getCanonicalName(),
+                        securityIdentity.getPrincipal().getName()),
+                "        </ul>",
+                "        <p>Custom Principal usage - this check will return a result of <em>enabled</em> if the CustomPrincipal was injected properly:</p>",
+                "        <ul>",
+                customPrincipalFromType != null
+                        ? generateSecretsAccessString("SecurityContext", daysSinceLogin(customPrincipalFromType))
+                        : "        <li>The custom principal was not loaded from SecurityContext. Secrets access is <strong>disabled</strong>.</li>",
+                securityIdentity.getPrincipal().getClass() == CustomPrincipal.class
+                        ? generateSecretsAccessString("SecurityIdentity", daysSinceLogin((CustomPrincipal) securityIdentity.getPrincipal()))
+                        : "        <li>The custom principal was not loaded from SecurityIdentity. Secrets access is <strong>disabled</strong>.</li>",
+                "    </body>",
+                "</html>"
+        );
+    }
+
+    private CustomPrincipal retrieveCustomPrincipalByType() {
+        Set<CustomPrincipal> customPrincipals = securityContext.getPrincipalsByType(CustomPrincipal.class);
+        return customPrincipals.size() == 1 ? customPrincipals.iterator().next() : null;
+    }
+
+    /** @param principalProvider Name of the class or provider that returned the custom principal. */
+    private String generateSecretsAccessString(String principalProvider, long days) {
+        return String.format("        <li>%s reports last login <strong>%s</strong>. Secrets access is <strong>%s</strong>.</li>",
+                principalProvider,
+                (days != -1 ? String.format("was %d days ago", days) : "is not applicable"),
+                (days < 30 ? "enabled" : "disabled"));
+    }
+
+    public long daysSinceLogin(CustomPrincipal customPrincipal) {
+        if (customPrincipal != null) {
+            if (customPrincipal.getLastLoginTime().equals(customPrincipal.getCurrentLoginTime())) {
+                return -1;
+            } else {
+                return DAYS.between(customPrincipal.getLastLoginTime(), customPrincipal.getCurrentLoginTime());
+            }
+        } else return -1;
+    }
+}

--- a/custom-principal-elytron/application/src/main/java/org/wildfly/security/examples/SecurityFactory.java
+++ b/custom-principal-elytron/application/src/main/java/org/wildfly/security/examples/SecurityFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.examples;
+
+import java.io.Serializable;
+
+import org.wildfly.security.auth.server.SecurityDomain;
+import org.wildfly.security.auth.server.SecurityIdentity;
+
+import jakarta.enterprise.context.SessionScoped;
+import jakarta.enterprise.inject.Produces;
+
+/**
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ * @author <a href="mailto:carodrig@redhat.com">Cameron Rodriguez</a>
+ */
+@SessionScoped
+public class SecurityFactory implements Serializable {
+
+    private static final long serialVersionUID = 7484045912648260117L;
+
+    @Produces
+    public SecurityDomain getSecurityDomain() {
+        return SecurityDomain.getCurrent();
+    }
+
+    @Produces
+    public SecurityIdentity getSecurityIdentity(SecurityDomain securityDomain) {
+        return securityDomain.getCurrentSecurityIdentity();
+    }
+}

--- a/custom-principal-elytron/application/src/main/webapp/WEB-INF/beans.xml
+++ b/custom-principal-elytron/application/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,6 @@
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+          https://jakarta.ee/xml/ns/jakartaee
+          https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       bean-discovery-mode="all"/>

--- a/custom-principal-elytron/application/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/custom-principal-elytron/application/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,7 @@
+<jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.3">
+    <deployment>
+        <dependencies>
+            <module name="org.wildfly.security.examples.custom-principal-elytron-components"/>
+        </dependencies>
+    </deployment>
+</jboss-deployment-structure>

--- a/custom-principal-elytron/application/src/main/webapp/WEB-INF/web.xml
+++ b/custom-principal-elytron/application/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="
+            https://jakarta.ee/xml/ns/jakartaee
+            https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+         version="6.0">
+
+    <login-config>
+        <auth-method>BASIC</auth-method>
+        <realm-name>principalRealm</realm-name>
+    </login-config>
+
+</web-app>

--- a/custom-principal-elytron/application/src/main/webapp/index.html
+++ b/custom-principal-elytron/application/src/main/webapp/index.html
@@ -1,0 +1,6 @@
+<html>
+  <body>
+    <h2>Custom Principal Demo - Elytron</h2>
+    <a href="./secured">Access Secured Servlet</a>
+  </body>
+</html>

--- a/custom-principal-elytron/components/pom.xml
+++ b/custom-principal-elytron/components/pom.xml
@@ -1,0 +1,30 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.security.examples</groupId>
+        <artifactId>custom-principal-elytron</artifactId>
+        <version>2.0.0.Alpha1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>custom-principal-elytron-components</artifactId>
+    <version>2.0.0.Alpha1-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-elytron-integration</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-auth-server</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+    </build>
+</project>

--- a/custom-principal-elytron/components/src/main/java/org/wildfly/security/examples/CustomNameRewriter.java
+++ b/custom-principal-elytron/components/src/main/java/org/wildfly/security/examples/CustomNameRewriter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.examples;
+
+import java.util.regex.Pattern;
+
+import org.wildfly.extension.elytron.capabilities.PrincipalTransformer;
+import org.wildfly.security.auth.principal.NamePrincipal;
+import org.wildfly.security.auth.util.RegexNameRewriter;
+
+public class CustomNameRewriter {
+
+    /**
+     * Acts like {@link RegexNameRewriter}, but operates on both {@link CustomPrincipal} and other types of
+     * {@link java.security.Principal Principal} with a name set.
+     *
+     * @return a {@link PrincipalTransformer}. It will return {@link CustomPrincipal} if the input was the same type,
+     * otherwise {@link NamePrincipal} if there was a valid name for the Principal, and if not then the original principal.
+     */
+    static PrincipalTransformer asPrincipalTransformer(String pattern, String replacement, boolean replaceAll) {
+        return PrincipalTransformer.from(
+            principal -> {
+                if (principal == null) {
+                    return null;
+                } else if (principal.getName() != null){
+                    RegexNameRewriter regexRewriter = new RegexNameRewriter(Pattern.compile(pattern), replacement, replaceAll);
+                    String rewritten = regexRewriter.rewriteName(principal.getName());
+
+                    if (principal instanceof CustomPrincipal) {
+                        CustomPrincipal cPrincipal = (CustomPrincipal) principal;
+                        return rewritten == null ? null : new CustomPrincipal(rewritten,
+                                cPrincipal.getLastLoginTime(), cPrincipal.getCurrentLoginTime());
+                    } else { // CustomPrincipal not being used
+                        return rewritten == null ? null : new NamePrincipal(rewritten);
+                    }
+                } else return principal;
+            }
+        );
+    }
+}

--- a/custom-principal-elytron/components/src/main/java/org/wildfly/security/examples/CustomPostRealmTransformer.java
+++ b/custom-principal-elytron/components/src/main/java/org/wildfly/security/examples/CustomPostRealmTransformer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.examples;
+
+import java.security.Principal;
+
+import org.wildfly.extension.elytron.capabilities.PrincipalTransformer;
+
+/**
+ * A {@link PrincipalTransformer} to change the name of the {@link CustomPrincipal} after the realm is assigned.
+ *
+ * @author <a href="mailto:carodrig@redhat.com">Cameron Rodriguez</a>
+ */
+public class CustomPostRealmTransformer implements PrincipalTransformer {
+
+    private static final PrincipalTransformer delegate = CustomNameRewriter.asPrincipalTransformer(
+            "QuickstartUserPre", "QuickstartUserPost", false);
+
+    @Override
+    public Principal apply(Principal principal) {
+        return delegate.apply(principal);
+    }
+}

--- a/custom-principal-elytron/components/src/main/java/org/wildfly/security/examples/CustomPreRealmTransformer.java
+++ b/custom-principal-elytron/components/src/main/java/org/wildfly/security/examples/CustomPreRealmTransformer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.examples;
+
+import java.security.Principal;
+import java.time.LocalDateTime;
+
+import org.wildfly.extension.elytron.capabilities.PrincipalTransformer;
+
+/**
+ * A {@link PrincipalTransformer} to create a custom principal. An offset {@value LOGIN_DELTA_DAYS LOGIN_DELTA_DAYS} is used to simulate the time since the last
+ * user was logged in.
+ *
+ * @author <a href="mailto:carodrig@redhat.com">Cameron Rodriguez</a>
+ */
+public class CustomPreRealmTransformer implements PrincipalTransformer {
+
+    private static final int LOGIN_DELTA_DAYS = 10;
+    private static final PrincipalTransformer delegate = CustomNameRewriter.asPrincipalTransformer(
+            "quickstartUser", "customQuickstartUserPre", false);
+
+    @Override
+    public Principal apply(Principal principal) {
+        return new CustomPrincipal(delegate.apply(principal), LocalDateTime.now().minusDays(LOGIN_DELTA_DAYS));
+    }
+
+}

--- a/custom-principal-elytron/components/src/main/java/org/wildfly/security/examples/CustomPrincipal.java
+++ b/custom-principal-elytron/components/src/main/java/org/wildfly/security/examples/CustomPrincipal.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.examples;
+
+import java.io.Serializable;
+import java.security.Principal;
+import java.time.LocalDateTime;
+
+import org.wildfly.security.auth.principal.NamePrincipal;
+
+/**
+ * Custom implementation of a {@link Principal}, storing the timestamp when a user attempts to login,
+ * and of the last time they logged in.
+ *
+ * @author <a href="mailto:carodrig@redhat.com">Cameron Rodriguez</a>
+ */
+public class CustomPrincipal implements Principal, Serializable {
+
+    private static final long serialVersionUID = -7725026682598731089L;
+    private final LocalDateTime currentLoginTime;
+    private final LocalDateTime lastLoginTime;
+    private final Principal wrappedPrincipal;
+
+    public CustomPrincipal(Principal principal, LocalDateTime lastLoginTime) {
+        this.wrappedPrincipal = principal;
+        this.currentLoginTime = LocalDateTime.now();
+        this.lastLoginTime = lastLoginTime != null ? lastLoginTime : this.currentLoginTime;
+    }
+
+    // Used for rewriting names of existing principals
+    CustomPrincipal(String name, LocalDateTime lastLoginTime, LocalDateTime currentLoginTime) {
+        this.wrappedPrincipal = new NamePrincipal(name);
+        this.currentLoginTime = currentLoginTime;
+        this.lastLoginTime = lastLoginTime;
+    }
+
+    public LocalDateTime getCurrentLoginTime() {
+        return this.currentLoginTime;
+    }
+
+    public LocalDateTime getLastLoginTime() {
+        return this.lastLoginTime;
+    }
+    @Override
+    public String getName() {
+        return wrappedPrincipal.getName();
+    }
+
+    @Override
+    public String toString() {
+        return getName();
+    }
+
+    @Override
+    public boolean equals(final Object object) {
+        return object instanceof CustomPrincipal && this.equals((CustomPrincipal)object);
+    }
+
+    // Only compares names
+    public boolean equals(final CustomPrincipal principal) {
+        return principal.getName().equals(this.getName());
+    }
+}

--- a/custom-principal-elytron/configure-elytron.cli
+++ b/custom-principal-elytron/configure-elytron.cli
@@ -1,0 +1,28 @@
+# Load custom components module
+module add --name=org.wildfly.security.examples.custom-principal-elytron-components --resources=/PATH/TO/elytron-examples/custom-principal-elytron/components/target/custom-principal-elytron-components.jar --dependencies=org.wildfly.security.elytron,org.wildfly.extension.elytron
+
+# Start batching
+batch
+
+# Enable a default JACC policy for Elytron
+/subsystem=elytron/policy=jacc:add(jacc-policy={})
+
+# Create security realm and identity
+/subsystem=elytron/filesystem-realm=principalRealm:add(path=principal-realm,relative-to=jboss.server.config.dir)
+/subsystem=elytron/filesystem-realm=principalRealm:add-identity(identity=customQuickstartUserPost)
+/subsystem=elytron/filesystem-realm=principalRealm:set-password(identity=customQuickstartUserPost,clear={password=password123!})
+/subsystem=elytron/filesystem-realm=principalRealm:add-identity-attribute(identity=customQuickstartUserPost,name=Roles,value=[Login])
+
+# Add custom pre-realm principal transformer and post-realm regex rewriter (a type of transformer)
+/subsystem=elytron/custom-principal-transformer=customPreRealmTransformer:add(module=org.wildfly.security.examples.custom-principal-elytron-components,class-name=org.wildfly.security.examples.CustomPreRealmTransformer)
+/subsystem=elytron/custom-principal-transformer=customPostRealmRewriter:add(module=org.wildfly.security.examples.custom-principal-elytron-components,class-name=org.wildfly.security.examples.CustomPostRealmTransformer)
+
+# Create security domain, add realms and transformers
+/subsystem=elytron/security-domain=principalSecDomain:add(realms=[{realm=principalRealm}],default-realm=principalRealm,pre-realm-principal-transformer=customPreRealmTransformer,post-realm-principal-transformer=customPostRealmRewriter,permission-mapper=default-permission-mapper)
+
+# Add the security domain factory mapping to Undertow
+/subsystem=undertow/application-security-domain=other:write-attribute(name=security-domain, value=principalSecDomain)
+
+# Run batch
+run-batch
+reload

--- a/custom-principal-elytron/pom.xml
+++ b/custom-principal-elytron/pom.xml
@@ -1,0 +1,64 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.wildfly.security.examples</groupId>
+    <artifactId>custom-principal-elytron</artifactId>
+    <version>2.0.0.Alpha1-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+
+        <version.org.wildfly.core.wildfly-elytron-integration>20.0.0.Beta7</version.org.wildfly.core.wildfly-elytron-integration>
+        <version.org.wildfly.plugins.wildfly-maven-plugin>4.0.0.Final</version.org.wildfly.plugins.wildfly-maven-plugin>
+        <version.server.bom>27.0.1.Final</version.server.bom>
+    </properties>
+
+    <modules>
+        <module>components</module>
+        <module>application</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.wildfly.security.examples</groupId>
+                <artifactId>custom-principal-elytron-components</artifactId>
+                <version>${project.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-ee-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.core</groupId>
+                <artifactId>wildfly-elytron-integration</artifactId>
+                <version>${version.org.wildfly.core.wildfly-elytron-integration}</version>
+                <scope>provided</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.wildfly.plugins</groupId>
+                    <artifactId>wildfly-maven-plugin</artifactId>
+                    <version>${version.org.wildfly.plugins.wildfly-maven-plugin}</version>
+                    <configuration>
+                        <skip>true</skip>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/custom-principal-elytron/restore-configuration.cli
+++ b/custom-principal-elytron/restore-configuration.cli
@@ -1,0 +1,28 @@
+# Start batching
+batch
+
+# Restore the security domain mapping to Undertow
+/subsystem=undertow/application-security-domain=other:write-attribute(name=security-domain,value=ApplicationDomain)
+
+# Remove the security domain
+/subsystem=elytron/security-domain=principalSecDomain:remove()
+
+# Remove pre-realm and post-realm transformers
+/subsystem=elytron/custom-principal-transformer=customPostRealmRewriter:remove()
+/subsystem=elytron/custom-principal-transformer=customPreRealmTransformer:remove()
+
+# Remove security identity and default JACC policy for Elytron
+/subsystem=elytron/filesystem-realm=principalRealm:remove-identity(identity=customQuickstartUserPost)
+/subsystem=elytron/policy=jacc:remove()
+
+# Run batch
+run-batch
+reload
+
+# Remove security realm and custom components module
+batch
+/subsystem=elytron/filesystem-realm=principalRealm:remove()
+module remove --name=org.wildfly.security.examples.custom-principal-elytron-components
+run-batch
+reload
+


### PR DESCRIPTION
These examples would serve as a demonstration of how to implement a custom principal, and ways to retrieve that principal from the server. The demos are:

- `custom-principal-ejb`: Focuses on retrieving principals from EJBs, mainly `jakarta.ejb.EJBContext`.
- `custom-principal-ee`: Retrieving principals from a Jakarta EE Security implementation using `SecurityContext`.
- `custom-principal-elytron`: Retrieving custom principals using Elytron-provided methods, like `getRealmIdentityPrincipal`, as well as `SecurityContext`.

These quickstarts are dependent on changes in ELY-2468 (wildfly-security/wildfly-elytron#1810). For more information, see [EAP7-1880](https://issues.redhat.com/browse/EAP7-1880) and [WFLY-17541](https://issues.redhat.com/browse/WFLY-17541).