### PR TITLE
[ELY-2674] Migrate resteasy-client-integration to Jakarta EE 10 and m…

### DIFF
--- a/resteasy-client-integration/README.md
+++ b/resteasy-client-integration/README.md
@@ -10,7 +10,7 @@
 We have added new user jane to the security domain and set HTTP BASIC authentication for application security domain.
 Please see content of configure.cli for more information.
 
-* Configure mutual SSL on your running wildfly instance. You can read how to do it here: [two-way SSL in Wildfly](https://docs.jboss.org/author/display/WFLY/Using%20the%20Elytron%20Subsystem.html#110231569_UsingtheElytronSubsystem-EnableTwowaySSL%2FTLSinWildFlyforApplications)
+* Configure mutual SSL on your running wildfly instance. You can read how to do it here: [two-way SSL in Wildfly](https://docs.wildfly.org/29/WildFly_Elytron_Security.html#enable-two-way-ssltls-in-wildfly-for-applications)
 
 * Configure path to client's keystore and truststore in this project's *wildfly-config.xml* accordingly
 

--- a/resteasy-client-integration/client/pom.xml
+++ b/resteasy-client-integration/client/pom.xml
@@ -7,28 +7,49 @@
     <version>2.0.0.Alpha1-SNAPSHOT</version>
     <artifactId>client</artifactId>
     <packaging>jar</packaging>
+
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <version.wildfly-client-all>29.0.1.Final</version.wildfly-client-all>
+        <version.junit>4.13.2</version.junit>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.wildfly</groupId>
+                <artifactId>wildfly-client-all</artifactId>
+                <version>${version.wildfly-client-all}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security.jakarta</groupId>
+            <artifactId>jakarta-client-webservices</artifactId>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+             <version>${version.junit}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>3.14.0.Final</version>
-            <scope>test</scope>
-        </dependency>
-        <!-- https://mvnrepository.com/artifact/org.wildfly/wildfly-client-all -->
-        <dependency>
-            <groupId>org.wildfly</groupId>
-            <artifactId>wildfly-client-all</artifactId>
-            <version>21.0.0.Beta1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/resteasy-client-integration/client/src/main/resources/META-INF/wildfly-config.xml
+++ b/resteasy-client-integration/client/src/main/resources/META-INF/wildfly-config.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <configuration>
-    <authentication-client xmlns="urn:elytron:client:1.5">
+    <authentication-client xmlns="urn:elytron:client:1.7">
         <authentication-rules>
             <rule use-configuration="auth-config" />
         </authentication-rules>
         <key-stores>
-            <key-store name="truststore" type="JKS">
-                <file name="/path/to/client.truststore.jks"/>
+            <key-store name="truststore" type="PKCS12">
+                <file name="/PATH/TOclient.truststore.pkcs12"/>
                 <key-store-clear-password password="secret"/>
             </key-store>
-            <key-store name="keystore" type="JKS">
-                <file name="/path/to/client.keystore.jks"/>
+            <key-store name="keystore" type="PKCS12">
+                <file name="/PATH/TO/client.keystore.pkcs12"/>
                 <key-store-clear-password password="secret"/>
             </key-store>
         </key-stores>

--- a/resteasy-client-integration/client/src/test/java/Client.java
+++ b/resteasy-client-integration/client/src/test/java/Client.java
@@ -4,7 +4,8 @@ import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.junit.Assert;
 import org.junit.Test;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Response;
 
 /**
  * Client test method demonstrating RESTEasy client integration with Elytron client.
@@ -15,8 +16,9 @@ public class Client {
 
     @Test
     public void test() {
-        ResteasyClient client = new ResteasyClientBuilder().hostnameVerifier(NoopHostnameVerifier.INSTANCE).build();
-        Response response = client.target("https://127.0.0.1:8443/resteasy-client-integration-example/rest/hello").request().get();
+        ((ResteasyClientBuilder)ClientBuilder.newBuilder()).hostnameVerifier(NoopHostnameVerifier.INSTANCE);
+        ResteasyClient sslClient = (ResteasyClient) ResteasyClientBuilder.newClient();
+        Response response = sslClient.target("https://127.0.0.1:8443/resteasy-client-integration-example/rest/hello").request().get();
         Assert.assertNotNull(response);
         Assert.assertEquals(response.getStatus(), 200);
         Assert.assertEquals(response.readEntity(String.class), "Hello jane");

--- a/resteasy-client-integration/server/pom.xml
+++ b/resteasy-client-integration/server/pom.xml
@@ -9,15 +9,30 @@
     <packaging>war</packaging>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <version.wildfly-ee-with-tools>29.0.1.Final</version.wildfly-ee-with-tools>
+        <version.jakarta.ws.rs-api>3.1.0</version.jakarta.ws.rs-api>
+        <version.wildfly-maven-plugin>4.2.0.Final</version.wildfly-maven-plugin>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-ee-with-tools</artifactId>
+                <version>${version.wildfly-ee-with-tools}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
-            <groupId>org.jboss.spec.javax.ws.rs</groupId>
-            <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
-            <version>1.0.2.Final</version>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+	    <scope>provided</scope>
         </dependency>
     </dependencies>
 
@@ -28,7 +43,7 @@
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-maven-plugin</artifactId>
-                <version>2.0.0.Final</version>
+                <version>${version.wildfly-maven-plugin}</version>
             </plugin>
         </plugins>
     </build>

--- a/resteasy-client-integration/server/src/main/java/org/wildfly/elytron/resteasy/client/example/HelloUser.java
+++ b/resteasy-client-integration/server/src/main/java/org/wildfly/elytron/resteasy/client/example/HelloUser.java
@@ -15,10 +15,10 @@
  */
 package org.wildfly.elytron.resteasy.client.example;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.SecurityContext;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.SecurityContext;
 
 /**
  * Simple REST endpoint that will be used to demonstrate RESTEasy client integration with Elytron client.

--- a/resteasy-client-integration/server/src/main/java/org/wildfly/elytron/resteasy/client/example/JAXActivator.java
+++ b/resteasy-client-integration/server/src/main/java/org/wildfly/elytron/resteasy/client/example/JAXActivator.java
@@ -15,8 +15,8 @@
  */
 package org.wildfly.elytron.resteasy.client.example;
 
-import javax.ws.rs.ApplicationPath;
-import javax.ws.rs.core.Application;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
 
 /**
  * JAXActivator is an arbitrary name, what is important is that javax.ws.rs.core.Application is extended


### PR DESCRIPTION
…ake sure it runs on recent versions of WF (Fails with Client.test:23 » Processing RESTEASY004655: Unable to invoke request: javax.net.ssl.SSLHandshakeException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target)

https://issues.redhat.com/browse/ELY-2674