### PR TITLE
Use ejb client artifact to call ejb basic in oidc-with-identity-propagation

### DIFF
--- a/oidc-with-identity-propagation/configure-server.cli
+++ b/oidc-with-identity-propagation/configure-server.cli
@@ -18,7 +18,8 @@ batch
 /subsystem=ejb3/application-security-domain=BusinessDomain:add(security-domain=BusinessDomain)
 
 /subsystem=elytron/virtual-security-domain=virtual-security-domain-to-domain.ear:add(outflow-security-domains=[BusinessDomain])
-/subsystem=elytron/security-domain=BusinessDomain:write-attribute(name=trusted-virtual-security-domains, value=[virtual-security-domain-to-domain.ear])
+/subsystem=elytron/virtual-security-domain=ejb-basic.ear:add(outflow-security-domains=[BusinessDomain])
+/subsystem=elytron/security-domain=BusinessDomain:write-attribute(name=trusted-virtual-security-domains, value=[virtual-security-domain-to-domain.ear, ejb-basic.ear])
 
 # Run the batch commands
 run-batch

--- a/oidc-with-identity-propagation/ejb-basic/ejb/pom.xml
+++ b/oidc-with-identity-propagation/ejb-basic/ejb/pom.xml
@@ -25,6 +25,7 @@
         <version>2.0.0.Alpha1-SNAPSHOT</version>
     </parent>
     <artifactId>ejb-basic-ejb</artifactId>
+    <packaging>ejb</packaging>
 
     <dependencies>
         <dependency>
@@ -53,8 +54,18 @@
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-maven-plugin</artifactId>
+                <version>5.1.1.Final</version>
                 <configuration>
                     <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-ejb-plugin</artifactId>
+                <version>3.2.1</version>
+                <configuration>
+                    <ejbVersion>3.1</ejbVersion>
+                    <generateClient>true</generateClient>
                 </configuration>
             </plugin>
         </plugins>

--- a/oidc-with-identity-propagation/virtual-security-domain-to-domain/ejb/pom.xml
+++ b/oidc-with-identity-propagation/virtual-security-domain-to-domain/ejb/pom.xml
@@ -7,6 +7,7 @@
         <version>2.0.0.Alpha1-SNAPSHOT</version>
     </parent>
     <artifactId>virtual-security-domain-to-domain-ejb</artifactId>
+    <packaging>ejb</packaging>
 
     <dependencies>
         <dependency>
@@ -31,7 +32,7 @@
         <dependency>
             <groupId>org.wildfly.security.examples</groupId>
             <artifactId>ejb-basic-ejb</artifactId>
-            <type>ejb</type>
+            <type>ejb-client</type>
             <version>${project.version}</version>
         </dependency>
     </dependencies>

--- a/oidc-with-identity-propagation/virtual-security-domain-to-domain/ejb/src/main/java/org/wildfly/security/examples/virtual_security_domain_to_domain/ejb/EntryBean.java
+++ b/oidc-with-identity-propagation/virtual-security-domain-to-domain/ejb/src/main/java/org/wildfly/security/examples/virtual_security_domain_to_domain/ejb/EntryBean.java
@@ -53,7 +53,7 @@ public class EntryBean {
 
     @PermitAll
     public String invokeManagementBean() {
-        Management management = lookup(Management.class, "java:global/virtual-security-domain-to-domain/ejb-basic-ejb/ManagementBean!org.wildfly.security.examples.ejb_basic.ejb.Management");
+        Management management = lookup(Management.class, "java:global/ejb-basic/ejb-basic-ejb/ManagementBean!org.wildfly.security.examples.ejb_basic.ejb.Management");
         return management.adminOnlyMethod();
     }
 

--- a/oidc-with-identity-propagation/virtual-security-domain-to-domain/web/src/main/java/org/wildfly/security/examples/virtual_security_domain_to_domain/web/SecuredServlet.java
+++ b/oidc-with-identity-propagation/virtual-security-domain-to-domain/web/src/main/java/org/wildfly/security/examples/virtual_security_domain_to_domain/web/SecuredServlet.java
@@ -43,7 +43,7 @@ public class SecuredServlet extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        EntryBean bean = lookup(EntryBean.class, "java:global/virtual-security-domain-to-domain/virtual-security-domain-to-domain-ejb/EntryBean");
+        EntryBean bean = lookup(EntryBean.class, "java:global/virtual-security-domain-to-domain/virtual-security-domain-to-domain-ejb/EntryBean!org.wildfly.security.examples.virtual_security_domain_to_domain.ejb.EntryBean");
         final PrintWriter writer = resp.getWriter();
 
         writer.println("<html><head><title>virtual-security-domain-to-domain</title></head><body>");


### PR DESCRIPTION
Hi

tried to write an issue first but explaining with code changes seems to be easier for me.
If you think this is not an issue just delete the PR.

In your article
https://wildfly-security.github.io/wildfly-elytron/blog/wildfly-oidc-identity-propagation/#secure-an-ejb-invoked-by-an-oidc-app-using-a-different-security-domain

you explain how to do identity propagation. Example works as described. But when I only deploy virtual-security-domain-to-domain.ear do not deploy ejb-basic.ear, the example still works.
What should not be the case in my opinion.
When I examined the example the explanation was obvious. On the virtual-security-domain-to-domain.ear the ejb-basic-ejb was included as well. I think there you should only have the ejb-basic-ejb client not the whole ejb (interface and implementation).
If you check my code changes I now create the ejb-basic-ejb-client.jar as well and include this in virtual-security-domain-to-domain.ear. Then I had to change the jndi names a little bit so they could be found. Lastly I had to adjust the cli to connect the ejb-basic.ear virtual security doamain to the BusinessDomain. 
Example then behaves the same but if you miss deploying ejb-basic.ear it's not working anymore (as I would expect).

I am correct or did I misunderstood the example?
Best regards
joachim
